### PR TITLE
Copy DMDirc jars into dist.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,6 +170,15 @@ jar {
     }
 }
 
+jar.doLast {
+    copy {
+        from jar.archivePath
+        into "dist/"
+        rename ".*", "DMDirc.jar"
+    }
+}
+jar.outputs.file "dist/DMDirc.jar"
+
 buildscript {
     repositories {
         mavenCentral()


### PR DESCRIPTION
This copies the build/libs/client-<version>.jar jar into
dist/DMDirc.jar.

Fixes #30
