### PR TITLE
Don't part if the server is closing.

### DIFF
--- a/src/com/dmdirc/Channel.java
+++ b/src/com/dmdirc/Channel.java
@@ -303,7 +303,7 @@ public class Channel extends MessageTarget implements GroupChat {
         }
 
         // Trigger any actions neccessary
-        if (isOnChannel) {
+        if (isOnChannel && server.getState() != ServerState.CLOSING) {
             part(getConfigManager().getOption("general", "partmessage"));
         }
 


### PR DESCRIPTION
This stops us leaving all channels when closing a server through
the treeview, which is inefficient at best, and destructive to
bouncer users.

Fixes issue #17
