### PR TITLE
Fix createVersionConfig breaking in some cases.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,6 +153,7 @@ task createVersionConfig << {
        java.nio.file.StandardCopyOption.REPLACE_EXISTING);
 }
 
+createVersionConfig.dependsOn classes
 jar.dependsOn createVersionConfig
 test.dependsOn createVersionConfig
 


### PR DESCRIPTION
We need to have built the classes so the directories exist.
Seems like this doesn't work on completely clean checkouts.
