### PR TITLE
Don't pre-download dependencies for Circle.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,9 +29,6 @@ checkout:
         pwd:
           ../meta/client
 
-dependencies:
-  override: []
-
 test:
   override:
     - ./gradlew --stacktrace --parallel client:jar client:test:


### PR DESCRIPTION
This seems to save 20-30 secs.
