### PR TITLE
Tidy up gradle source sets.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,20 +68,12 @@ publishing {
 
 sourceSets {
     main {
-        java {
-            srcDir 'src'
-        }
-        resources {
-            srcDir 'res'
-        }
+        java.srcDirs = ['src']
+        resources.srcDirs = ['res']
     }
     test {
-        java {
-             srcDir 'test'
-        }
-        resources {
-            srcDir 'test-res'
-        }
+        java.srcDirs = ['test']
+        resources.srcDirs = ['test-res']
     }
 }
 


### PR DESCRIPTION
This replaces the default source directories (src/main/java, etc)
with our own, instead of just appending ours to the list.
