### PR TITLE
Make dependencies use gradlew again.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,6 +29,11 @@ checkout:
         pwd:
           ../meta/client
 
+dependencies:
+  override:
+    - ./gradlew dependencies:
+        pwd: ../meta
+
 test:
   override:
     - ./gradlew --stacktrace --parallel client:jar client:test:


### PR DESCRIPTION
This should cache the gradle binary and save us a load of time.
