### PR TITLE
Separate most swing logic from core model.

### DIFF
--- a/src/com/dmdirc/ui/messages/AttributedStringMessageMaker.java
+++ b/src/com/dmdirc/ui/messages/AttributedStringMessageMaker.java
@@ -20,11 +20,9 @@
  * SOFTWARE.
  */
 
-package com.dmdirc.ui.core.util;
+package com.dmdirc.ui.messages;
 
-import com.dmdirc.ui.messages.IRCTextAttribute;
-import com.dmdirc.ui.messages.StyledDocumentMaker;
-import com.dmdirc.ui.messages.Styliser;
+import com.dmdirc.ui.core.util.ExtendedAttributedString;
 
 import java.awt.Font;
 import java.awt.font.TextAttribute;
@@ -34,38 +32,46 @@ import java.util.Enumeration;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Element;
-import javax.swing.text.StyleConstants.CharacterConstants;
-import javax.swing.text.StyleConstants.ColorConstants;
-import javax.swing.text.StyleConstants.FontConstants;
+import javax.swing.text.StyleConstants;
 import javax.swing.text.StyledDocument;
 
 /**
- * Core UI Utilities.
+ * Creates an attributed string from a styled document.
  */
-public final class Utils {
+public class AttributedStringMessageMaker
+        extends DelegatingStyledMessageMaker<StyledDocument, AttributedString> {
 
-    /** Prevent instantiation. */
-    private Utils() {
+    private String fontName;
+    private int fontSize;
+
+    public AttributedStringMessageMaker() {
+        super(new StyledDocumentMaker());
     }
 
-    /**
-     * Converts a StyledDocument into an AttributedString.
-     *
-     * @param styliser  The styliser to use to style the string
-     * @param lineParts Parts of a line comprising the whole
-     * @param fontName  Default font name to use
-     * @param fontSize  Default font size to use
-     *
-     * @return AttributedString representing the specified StyledDocument
-     */
-    public static ExtendedAttributedString getAttributedString(final Styliser styliser,
-            final String[] lineParts, final String fontName, final int fontSize) throws
-            BadLocationException {
-        final StyledDocument doc = styliser.getStyledString(lineParts, new StyledDocumentMaker());
+    @Override
+    public int getMaximumFontSize() {
+        return fontSize;
+    }
 
-        final Element line = doc.getParagraphElement(0);
-        final AttributedString attString = new AttributedString(line.getDocument().getText(0,
-                line.getDocument().getLength()));
+    @Override
+    public void setDefaultFont(final String fontName, final int fontSize) {
+        this.fontName = fontName;
+        this.fontSize = fontSize;
+    }
+
+    @Override
+    protected AttributedString convert(final StyledDocument styledMessage) {
+        final Element line = styledMessage.getParagraphElement(0);
+        final AttributedString attString;
+        try {
+            attString = new AttributedString(
+                    line.getDocument().getText(0,
+                    line.getDocument().getLength()));
+        } catch (BadLocationException ex) {
+            // Shouldn't happen
+            return null;
+        }
+
         if (attString.getIterator().getEndIndex() != 0) {
             final Font font = new Font(fontName, Font.PLAIN, fontSize);
             attString.addAttribute(TextAttribute.SIZE, font.getSize());
@@ -101,54 +107,47 @@ public final class Utils {
                     attString.addAttribute(IRCTextAttribute.TOOLTIP,
                             as.getAttribute(attrib), element.getStartOffset(),
                             element.getEndOffset());
-                } else if (attrib == ColorConstants.Foreground) {
+                } else if (attrib == StyleConstants.Foreground) {
                     //Foreground
                     attString.addAttribute(TextAttribute.FOREGROUND,
                             as.getAttribute(attrib), element.getStartOffset(),
                             element.getEndOffset());
-                } else if (attrib == ColorConstants.Background) {
+                } else if (attrib == StyleConstants.Background) {
                     //Background
                     attString.addAttribute(TextAttribute.BACKGROUND,
                             as.getAttribute(attrib), element.getStartOffset(),
                             element.getEndOffset());
-                } else if (attrib == FontConstants.Bold) {
+                } else if (attrib == StyleConstants.Bold) {
                     //Bold
                     attString.addAttribute(TextAttribute.WEIGHT,
                             TextAttribute.WEIGHT_BOLD, element.getStartOffset(),
                             element.getEndOffset());
-                } else if (attrib == FontConstants.Family) {
+                } else if (attrib == StyleConstants.Family) {
                     //Family
                     attString.addAttribute(TextAttribute.FAMILY,
                             as.getAttribute(attrib), element.getStartOffset(),
                             element.getEndOffset());
-                } else if (attrib == FontConstants.Italic) {
+                } else if (attrib == StyleConstants.Italic) {
                     //italics
                     attString.addAttribute(TextAttribute.POSTURE,
                             TextAttribute.POSTURE_OBLIQUE,
                             element.getStartOffset(),
                             element.getEndOffset());
-                } else if (attrib == CharacterConstants.Underline) {
+                } else if (attrib == StyleConstants.Underline) {
                     //Underline
                     attString.addAttribute(TextAttribute.UNDERLINE,
                             TextAttribute.UNDERLINE_ON, element.getStartOffset(),
                             element.getEndOffset());
-                } /* else if (attrib == IRCTextAttribute.SMILEY) { Lets avoid showing broken smileys
-                 * shall we! final Image image = IconManager.getIconManager().getImage((String)
-                 * as.getAttribute(attrib)). getScaledInstance(14, 14, Image.SCALE_DEFAULT);
-                 * ImageGraphicAttribute iga = new ImageGraphicAttribute(image, (int)
-                 * BOTTOM_ALIGNMENT, 5, 5); attString.addAttribute(TextAttribute.CHAR_REPLACEMENT,
-                 * iga, element.getStartOffset(), element.getEndOffset());
-                 *
-                 * } */
-
+                }
             }
         }
 
-        if (attString.getIterator().getEndIndex() == 0) {
-            return new ExtendedAttributedString(new AttributedString("\n"), fontSize);
-        }
-
-        return new ExtendedAttributedString(attString, fontSize);
+        final ExtendedAttributedString attributedString =
+                attString.getIterator().getEndIndex() == 0
+                        ? new ExtendedAttributedString(new AttributedString("\n"), fontSize)
+                        : new ExtendedAttributedString(attString, fontSize);
+        fontSize = attributedString.getMaxLineHeight();
+        return attributedString.getAttributedString();
     }
 
 }

--- a/src/com/dmdirc/ui/messages/BackBuffer.java
+++ b/src/com/dmdirc/ui/messages/BackBuffer.java
@@ -53,7 +53,7 @@ public class BackBuffer {
                 owner.getConnection().orElse(null),
                 owner.getConfigManager(),
                 colourManagerFactory.getColourManager(owner.getConfigManager()));
-        this.document = new IRCDocument(owner.getConfigManager(), styliser, owner.getEventBus());
+        this.document = new IRCDocument(owner.getConfigManager(), styliser);
         this.eventBus = owner.getEventBus();
         this.formatter = formatter;
         this.configProvider = owner.getConfigManager();

--- a/src/com/dmdirc/ui/messages/CachingDocument.java
+++ b/src/com/dmdirc/ui/messages/CachingDocument.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2006-2014 DMDirc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.dmdirc.ui.messages;
+
+import com.dmdirc.util.collections.RollingList;
+
+/**
+ * Wraps an {@link IRCDocument} and caches recent lines.
+ */
+public class CachingDocument<T> {
+
+    /** The document to wrap and cache data from. */
+    private final IRCDocument document;
+    /** The maker to use to produce styled lines. */
+    private final StyledMessageMaker<T> maker;
+    /** Cached lines. */
+    private final RollingList<Line> cachedLines;
+    /** Cached attributed strings. */
+    private final RollingList<T> cachedStrings;
+
+    public CachingDocument(final IRCDocument document, final StyledMessageMaker<T> maker) {
+        this.document = document;
+        this.maker = maker;
+
+        cachedLines = new RollingList<>(50);
+        cachedStrings = new RollingList<>(50);
+    }
+
+    /**
+     * Returns an attributed character iterator for a particular line, utilising the document cache
+     * where possible.
+     *
+     * @param line Line to be styled
+     *
+     * @return Styled line
+     */
+    protected T getStyledLine(final Line line) {
+        T styledLine = null;
+
+        if (cachedLines.contains(line)) {
+            final int index = cachedLines.getList().indexOf(line);
+            styledLine = cachedStrings.get(index);
+        }
+
+        if (styledLine == null) {
+            styledLine = line.getStyled(maker);
+            cachedLines.add(line);
+            cachedStrings.add(styledLine);
+        }
+
+        return styledLine;
+    }
+
+    /**
+     * Returns an attributed string for a particular line, utilising the document cache where
+     * possible.
+     *
+     * @param line Line number to be styled
+     *
+     * @return Styled line
+     */
+    public T getStyledLine(final int line) {
+        return getStyledLine(document.getLine(line));
+    }
+
+    public int getNumLines() {
+        return document.getNumLines();
+    }
+
+    public Line getLine(final int line) {
+        return document.getLine(line);
+    }
+
+}

--- a/src/com/dmdirc/ui/messages/DelegatingStyledMessageMaker.java
+++ b/src/com/dmdirc/ui/messages/DelegatingStyledMessageMaker.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2006-2014 DMDirc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.dmdirc.ui.messages;
+
+import com.dmdirc.util.colours.Colour;
+
+/**
+ * Delegates handling of styled messages to another maker, allowing the output to be mutated.
+ */
+public abstract class DelegatingStyledMessageMaker<S, T> implements StyledMessageMaker<T> {
+
+    private final StyledMessageMaker<S> delegatedMaker;
+
+    public DelegatingStyledMessageMaker(final StyledMessageMaker<S> delegatedMaker) {
+        this.delegatedMaker = delegatedMaker;
+    }
+
+    protected abstract T convert(S styledMessage);
+
+    @Override
+    public T getStyledMessage() {
+        return convert(delegatedMaker.getStyledMessage());
+    }
+
+    @Override
+    public void resetAllStyles() {
+        delegatedMaker.resetAllStyles();
+    }
+
+    @Override
+    public void resetColours() {
+        delegatedMaker.resetColours();
+    }
+
+    @Override
+    public void appendString(final String text) {
+        delegatedMaker.appendString(text);
+    }
+
+    @Override
+    public void toggleBold() {
+        delegatedMaker.toggleBold();
+    }
+
+    @Override
+    public void toggleUnderline() {
+        delegatedMaker.toggleUnderline();
+    }
+
+    @Override
+    public void toggleItalic() {
+        delegatedMaker.toggleItalic();
+    }
+
+    @Override
+    public void startHyperlink(final String url) {
+        delegatedMaker.startHyperlink(url);
+    }
+
+    @Override
+    public void endHyperlink() {
+        delegatedMaker.endHyperlink();
+    }
+
+    @Override
+    public void toggleHyperlinkStyle(final Colour colour) {
+        delegatedMaker.toggleHyperlinkStyle(colour);
+    }
+
+    @Override
+    public void startChannelLink(final String channel) {
+        delegatedMaker.startChannelLink(channel);
+    }
+
+    @Override
+    public void endChannelLink() {
+        delegatedMaker.endChannelLink();
+    }
+
+    @Override
+    public void toggleChannelLinkStyle(final Colour colour) {
+        delegatedMaker.toggleChannelLinkStyle(colour);
+    }
+
+    @Override
+    public void startNicknameLink(final String nickname) {
+        delegatedMaker.startNicknameLink(nickname);
+    }
+
+    @Override
+    public void endNicknameLink() {
+        delegatedMaker.endNicknameLink();
+    }
+
+    @Override
+    public void toggleFixedWidth() {
+        delegatedMaker.toggleFixedWidth();
+    }
+
+    @Override
+    public void setForeground(final Colour colour) {
+        delegatedMaker.setForeground(colour);
+    }
+
+    @Override
+    public void setDefaultForeground(final Colour colour) {
+        delegatedMaker.setDefaultForeground(colour);
+    }
+
+    @Override
+    public void setBackground(final Colour colour) {
+        delegatedMaker.setBackground(colour);
+    }
+
+    @Override
+    public void setDefaultBackground(final Colour colour) {
+        delegatedMaker.setDefaultBackground(colour);
+    }
+
+    @Override
+    public void startSmilie(final String smilie) {
+        delegatedMaker.startSmilie(smilie);
+    }
+
+    @Override
+    public void endSmilie() {
+        delegatedMaker.endSmilie();
+    }
+
+    @Override
+    public void startToolTip(final String tooltip) {
+        delegatedMaker.startToolTip(tooltip);
+    }
+
+    @Override
+    public void endToolTip() {
+        delegatedMaker.endToolTip();
+    }
+
+    @Override
+    public void setDefaultFont(final String fontName, final int fontSize) {
+        delegatedMaker.setDefaultFont(fontName, fontSize);
+    }
+
+    @Override
+    public int getMaximumFontSize() {
+        return delegatedMaker.getMaximumFontSize();
+    }
+
+    @Override
+    public void clear() {
+        delegatedMaker.clear();
+    }
+
+}

--- a/src/com/dmdirc/ui/messages/Line.java
+++ b/src/com/dmdirc/ui/messages/Line.java
@@ -23,13 +23,8 @@
 package com.dmdirc.ui.messages;
 
 import com.dmdirc.events.DisplayPropertyMap;
-import com.dmdirc.ui.core.util.ExtendedAttributedString;
-import com.dmdirc.ui.core.util.Utils;
 
-import java.text.AttributedString;
 import java.util.Arrays;
-
-import javax.swing.text.BadLocationException;
 
 /**
  * Represents a line of text in IRC.
@@ -133,11 +128,12 @@ public class Line {
      *
      * @return AttributedString representing the specified StyledDocument
      */
-    public AttributedString getStyled() throws BadLocationException {
-        final ExtendedAttributedString string = Utils.getAttributedString(
-                styliser, getLineParts(), fontName, fontSize);
-        fontSize = string.getMaxLineHeight();
-        return string.getAttributedString();
+    public <T> T getStyled(final StyledMessageMaker<T> maker) {
+        maker.clear();
+        maker.setDefaultFont(fontName, fontSize);
+        final T styledString = styliser.getStyledString(getLineParts(), maker);
+        fontSize = maker.getMaximumFontSize();
+        return styledString;
     }
 
     @Override

--- a/src/com/dmdirc/ui/messages/StyledDocumentMaker.java
+++ b/src/com/dmdirc/ui/messages/StyledDocumentMaker.java
@@ -219,6 +219,28 @@ public class StyledDocumentMaker implements StyledMessageMaker<StyledDocument> {
         attribs.removeAttribute(IRCTextAttribute.TOOLTIP);
     }
 
+    @Override
+    public void setDefaultFont(final String fontName, final int fontSize) {
+        // Don't care
+    }
+
+    @Override
+    public int getMaximumFontSize() {
+        // Don't track
+        return 0;
+    }
+
+    @Override
+    public void clear() {
+        try {
+            attribs.removeAttribute("DefaultBackground");
+            attribs.removeAttribute("DefaultForeground");
+            document.remove(0, document.getLength());
+        } catch (BadLocationException ex) {
+            // Shouldn't happen
+        }
+    }
+
     /**
      * Toggles the specified attribute. If the attribute exists in the attribute set, it is removed.
      * Otherwise, it is added with a value of Boolean.True.

--- a/src/com/dmdirc/ui/messages/StyledMessageMaker.java
+++ b/src/com/dmdirc/ui/messages/StyledMessageMaker.java
@@ -79,4 +79,11 @@ public interface StyledMessageMaker<T> {
     void startToolTip(String tooltip);
 
     void endToolTip();
+
+    void setDefaultFont(String fontName, int fontSize);
+
+    int getMaximumFontSize();
+
+    void clear();
+
 }

--- a/test/com/dmdirc/ui/messages/StyliserStylesTest.java
+++ b/test/com/dmdirc/ui/messages/StyliserStylesTest.java
@@ -24,7 +24,6 @@ package com.dmdirc.ui.messages;
 
 import com.dmdirc.DMDircMBassador;
 import com.dmdirc.interfaces.config.AggregateConfigProvider;
-import com.dmdirc.ui.core.util.Utils;
 
 import java.awt.Color;
 import java.awt.font.TextAttribute;
@@ -41,8 +40,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
 @Ignore("Doesn't work in a headless environment (initialises an IRCDocument)")
@@ -72,9 +71,7 @@ public class StyliserStylesTest {
         final Styliser styliser = new Styliser(null, manager, new ColourManager(manager,
                 mock(DMDircMBassador.class)));
         styliser.addStyledString(new StyledDocumentMaker(doc), input);
-        final AttributedCharacterIterator aci = Utils.getAttributedString(styliser,
-                new String[]{input, }, "dialog", 12).
-                getAttributedString().getIterator();
+        final AttributedCharacterIterator aci = null; // TODO...
 
         Map<AttributedCharacterIterator.Attribute, Object> map = null;
         char chr = aci.current();


### PR DESCRIPTION
This introduces a CachingDocument which wraps around an IRCDocument
and allows UI-specific caching of UI-specific styled lines (so, e.g.
the web UI could cache HTML versions if it wanted).

Also adds a delegating message maker and attributed string maker,
which incorporates the old "make a StyledDoc then change it into
an AttributedString" logic found in ui.core.util.Utils.

Hopefully this should mean all the the swing stuff can be punted
into the swing UI. The delegated maker will also allow colouring
of the new events to be done sensibly, I think.
