### PR TITLE
Make HighlightManager raise events.

### DIFF
--- a/src/com/dmdirc/events/ChannelHighlightEvent.java
+++ b/src/com/dmdirc/events/ChannelHighlightEvent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2006-2014 DMDirc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.dmdirc.events;
+
+/**
+ * Event raised when a highlight is detected in a channel.
+ */
+public class ChannelHighlightEvent extends ChannelEvent {
+
+    private final ChannelEvent cause;
+
+    public ChannelHighlightEvent(final ChannelEvent cause) {
+        super(cause.getTimestamp(), cause.getChannel());
+        this.cause = cause;
+    }
+
+    public ChannelEvent getCause() {
+        return cause;
+    }
+
+}

--- a/src/com/dmdirc/events/QueryHighlightEvent.java
+++ b/src/com/dmdirc/events/QueryHighlightEvent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2006-2014 DMDirc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.dmdirc.events;
+
+/**
+ * Event raised when a highlight is detected in a query.
+ */
+public class QueryHighlightEvent extends QueryEvent {
+
+    private final QueryEvent cause;
+
+    public QueryHighlightEvent(final QueryEvent cause) {
+        super(cause.getTimestamp(), cause.getQuery());
+        this.cause = cause;
+    }
+
+    public QueryEvent getCause() {
+        return cause;
+    }
+
+}

--- a/src/com/dmdirc/ui/messages/HighlightManager.java
+++ b/src/com/dmdirc/ui/messages/HighlightManager.java
@@ -24,7 +24,9 @@ package com.dmdirc.ui.messages;
 
 import com.dmdirc.events.BaseChannelTextEvent;
 import com.dmdirc.events.BaseQueryTextEvent;
+import com.dmdirc.events.ChannelHighlightEvent;
 import com.dmdirc.events.DisplayProperty;
+import com.dmdirc.events.QueryHighlightEvent;
 import com.dmdirc.events.ServerConnectedEvent;
 import com.dmdirc.events.ServerNickchangeEvent;
 import com.dmdirc.parser.interfaces.LocalClientInfo;
@@ -47,12 +49,14 @@ public class HighlightManager {
             "(\\p{Space}|\\p{Punct}|$).*";
 
     private final Collection<Pattern> patterns = new ArrayList<>();
+
     private Optional<Pattern> nicknamePattern = Optional.empty();
 
     @Handler
     public void handleChannelMessage(final BaseChannelTextEvent event) {
         if (patterns.stream().anyMatch(p -> p.matcher(event.getMessage()).matches())) {
             event.setDisplayProperty(DisplayProperty.BACKGROUND_COLOUR, Colour.RED);
+            event.getChannel().getEventBus().publishAsync(new ChannelHighlightEvent(event));
         }
     }
 
@@ -60,6 +64,7 @@ public class HighlightManager {
     public void handleQueryMessage(final BaseQueryTextEvent event) {
         if (patterns.stream().anyMatch(p -> p.matcher(event.getMessage()).matches())) {
             event.setDisplayProperty(DisplayProperty.BACKGROUND_COLOUR, Colour.RED);
+            event.getQuery().getEventBus().publishAsync(new QueryHighlightEvent(event));
         }
     }
 


### PR DESCRIPTION
When a highlight is found, fire a {Channel,Query}HighlightEvent
pointing to the original event that caused the highlight.
