### PR TITLE
Decouple Server from ServerManager/WindowManager.

### DIFF
--- a/src/com/dmdirc/ChannelFactory.java
+++ b/src/com/dmdirc/ChannelFactory.java
@@ -22,9 +22,11 @@
 
 package com.dmdirc;
 
+import com.dmdirc.events.ChannelOpenedEvent;
 import com.dmdirc.interfaces.CommandController;
 import com.dmdirc.interfaces.config.ConfigProviderMigrator;
 import com.dmdirc.parser.interfaces.ChannelInfo;
+import com.dmdirc.ui.WindowManager;
 import com.dmdirc.ui.messages.BackBufferFactory;
 import com.dmdirc.ui.input.TabCompleterFactory;
 import com.dmdirc.ui.messages.sink.MessageSinkManager;
@@ -46,13 +48,14 @@ public class ChannelFactory {
     private final DMDircMBassador eventBus;
     private final BackBufferFactory backBufferFactory;
     private final GroupChatUserManager groupChatUserManager;
+    private final WindowManager windowManager;
 
     @Inject
     public ChannelFactory(final TabCompleterFactory tabCompleterFactory,
             final CommandController commandController, final MessageSinkManager messageSinkManager,
             final URLBuilder urlBuilder, final DMDircMBassador eventBus,
             final BackBufferFactory backBufferFactory,
-            final GroupChatUserManager groupChatUserManager) {
+            final GroupChatUserManager groupChatUserManager, final WindowManager windowManager) {
         this.tabCompleterFactory = tabCompleterFactory;
         this.commandController = commandController;
         this.messageSinkManager = messageSinkManager;
@@ -60,13 +63,17 @@ public class ChannelFactory {
         this.eventBus = eventBus;
         this.backBufferFactory = backBufferFactory;
         this.groupChatUserManager = groupChatUserManager;
+        this.windowManager = windowManager;
     }
 
     public Channel getChannel(final Server server,
             final ChannelInfo channelInfo,
             final ConfigProviderMigrator configMigrator) {
-        return new Channel(server, channelInfo, configMigrator, tabCompleterFactory,
-                commandController, messageSinkManager, urlBuilder, eventBus, backBufferFactory,
-                groupChatUserManager);
+        final Channel channel = new Channel(server, channelInfo, configMigrator,
+                tabCompleterFactory, commandController, messageSinkManager, urlBuilder, eventBus,
+                backBufferFactory, groupChatUserManager);
+        windowManager.addWindow(server, channel);
+        server.getEventBus().publish(new ChannelOpenedEvent(channel));
+        return channel;
     }
 }

--- a/src/com/dmdirc/QueryFactory.java
+++ b/src/com/dmdirc/QueryFactory.java
@@ -22,8 +22,10 @@
 
 package com.dmdirc;
 
+import com.dmdirc.events.QueryOpenedEvent;
 import com.dmdirc.interfaces.CommandController;
 import com.dmdirc.interfaces.User;
+import com.dmdirc.ui.WindowManager;
 import com.dmdirc.ui.messages.BackBufferFactory;
 import com.dmdirc.ui.input.TabCompleterFactory;
 import com.dmdirc.ui.messages.sink.MessageSinkManager;
@@ -43,21 +45,27 @@ public class QueryFactory {
     private final MessageSinkManager messageSinkManager;
     private final URLBuilder urlBuilder;
     private final BackBufferFactory backBufferFactory;
+    private final WindowManager windowManager;
 
     @Inject
     public QueryFactory(final TabCompleterFactory tabCompleterFactory,
             final CommandController commandController, final MessageSinkManager messageSinkManager,
-            final URLBuilder urlBuilder, final BackBufferFactory backBufferFactory) {
+            final URLBuilder urlBuilder, final BackBufferFactory backBufferFactory,
+            final WindowManager windowManager) {
         this.tabCompleterFactory = tabCompleterFactory;
         this.commandController = commandController;
         this.messageSinkManager = messageSinkManager;
         this.urlBuilder = urlBuilder;
         this.backBufferFactory = backBufferFactory;
+        this.windowManager = windowManager;
     }
 
     public Query getQuery(final Server server, final User user) {
-        return new Query(server, user, tabCompleterFactory, commandController,
+        final Query query = new Query(server, user, tabCompleterFactory, commandController,
                 messageSinkManager, urlBuilder, backBufferFactory);
+        windowManager.addWindow(server, query);
+        server.getEventBus().publish(new QueryOpenedEvent(query));
+        return query;
     }
 
 }

--- a/src/com/dmdirc/Server.java
+++ b/src/com/dmdirc/Server.java
@@ -26,8 +26,6 @@ import com.dmdirc.commandparser.CommandType;
 import com.dmdirc.commandparser.parsers.CommandParser;
 import com.dmdirc.config.profiles.Profile;
 import com.dmdirc.events.AppErrorEvent;
-import com.dmdirc.events.ChannelOpenedEvent;
-import com.dmdirc.events.QueryOpenedEvent;
 import com.dmdirc.events.ServerConnectErrorEvent;
 import com.dmdirc.events.ServerConnectedEvent;
 import com.dmdirc.events.ServerConnectingEvent;
@@ -55,7 +53,6 @@ import com.dmdirc.parser.interfaces.ProtocolDescription;
 import com.dmdirc.parser.interfaces.SecureParser;
 import com.dmdirc.parser.interfaces.StringConverter;
 import com.dmdirc.tls.CertificateManager;
-import com.dmdirc.ui.WindowManager;
 import com.dmdirc.ui.core.components.WindowComponent;
 import com.dmdirc.ui.input.TabCompleterFactory;
 import com.dmdirc.ui.input.TabCompletionType;
@@ -164,8 +161,6 @@ public class Server extends FrameContainer implements Connection {
     private final ParserFactory parserFactory;
     /** Factory to use to create new identities. */
     private final IdentityFactory identityFactory;
-    /** Window manager to pass to children. */
-    private final WindowManager windowManager;
     /** The migrator to use to change our config provider. */
     private final ConfigProviderMigrator configMigrator;
     /** Factory to use for creating channels. */
@@ -197,7 +192,6 @@ public class Server extends FrameContainer implements Connection {
             final TabCompleterFactory tabCompleterFactory,
             final IdentityFactory identityFactory,
             final MessageSinkManager messageSinkManager,
-            final WindowManager windowManager,
             final ChannelFactory channelFactory,
             final QueryFactory queryFactory,
             final URLBuilder urlBuilder,
@@ -227,7 +221,6 @@ public class Server extends FrameContainer implements Connection {
 
         this.parserFactory = parserFactory;
         this.identityFactory = identityFactory;
-        this.windowManager = windowManager;
         this.configMigrator = configMigrator;
         this.channelFactory = channelFactory;
         this.queryFactory = queryFactory;
@@ -531,10 +524,6 @@ public class Server extends FrameContainer implements Connection {
             if (!getState().isDisconnected()) {
                 newQuery.reregister();
             }
-
-            windowManager.addWindow(this, newQuery, focus);
-            getEventBus().publish(new QueryOpenedEvent(newQuery));
-
             getTabCompleter().addEntry(TabCompletionType.QUERY_NICK, nick);
             queries.put(lnick, newQuery);
         }
@@ -592,10 +581,6 @@ public class Server extends FrameContainer implements Connection {
             final ConfigProviderMigrator channelConfig = identityFactory.createMigratableConfig(
                     getProtocol(), getIrcd(), getNetwork(), getAddress(), chan.getName());
             final Channel newChan = channelFactory.getChannel(this, chan, channelConfig);
-
-            windowManager.addWindow(this, newChan, focus);
-            getEventBus().publish(new ChannelOpenedEvent(newChan));
-
             getTabCompleter().addEntry(TabCompletionType.CHANNEL, chan.getName());
             channels.add(newChan);
             return newChan;

--- a/src/com/dmdirc/Server.java
+++ b/src/com/dmdirc/Server.java
@@ -162,11 +162,9 @@ public class Server extends FrameContainer implements Connection {
     private StringConverter converter = new DefaultStringConverter();
     /** ParserFactory we use for creating parsers. */
     private final ParserFactory parserFactory;
-    /** ServerManager that created us. */
-    private final ServerManager manager;
     /** Factory to use to create new identities. */
     private final IdentityFactory identityFactory;
-    /** Window manager to pas to children. */
+    /** Window manager to pass to children. */
     private final WindowManager windowManager;
     /** The migrator to use to change our config provider. */
     private final ConfigProviderMigrator configMigrator;
@@ -193,7 +191,6 @@ public class Server extends FrameContainer implements Connection {
      * Creates a new server which will connect to the specified URL with the specified profile.
      */
     public Server(
-            final ServerManager manager,
             final ConfigProviderMigrator configMigrator,
             final CommandParser commandParser,
             final ParserFactory parserFactory,
@@ -228,7 +225,6 @@ public class Server extends FrameContainer implements Connection {
                         WindowComponent.INPUTFIELD.getIdentifier(),
                         WindowComponent.CERTIFICATE_VIEWER.getIdentifier()));
 
-        this.manager = manager;
         this.parserFactory = parserFactory;
         this.identityFactory = identityFactory;
         this.windowManager = windowManager;
@@ -884,8 +880,6 @@ public class Server extends FrameContainer implements Connection {
         channels.closeAll();
         closeQueries();
         removeInvites();
-
-        manager.unregisterServer(this);
 
         super.close();
     }

--- a/src/com/dmdirc/ServerFactoryImpl.java
+++ b/src/com/dmdirc/ServerFactoryImpl.java
@@ -50,7 +50,6 @@ public class ServerFactoryImpl {
     private final TabCompleterFactory tabCompleterFactory;
     private final IdentityFactory identityFactory;
     private final MessageSinkManager messageSinkManager;
-    private final WindowManager windowManager;
     private final Provider<ChannelFactory> channelFactory;
     private final Provider<QueryFactory> queryFactory;
     private final URLBuilder urlBuilder;
@@ -79,7 +78,6 @@ public class ServerFactoryImpl {
         this.tabCompleterFactory = tabCompleterFactory;
         this.identityFactory = identityFactory;
         this.messageSinkManager = messageSinkManager;
-        this.windowManager = windowManager;
         this.channelFactory = channelFactory;
         this.queryFactory = queryFactory;
         this.urlBuilder = urlBuilder;
@@ -97,7 +95,7 @@ public class ServerFactoryImpl {
             final URI uri,
             final Profile profile) {
         return new Server(configMigrator, commandParser, parserFactory,
-                tabCompleterFactory, identityFactory, messageSinkManager, windowManager,
+                tabCompleterFactory, identityFactory, messageSinkManager,
                 channelFactory.get(), queryFactory.get(), urlBuilder, eventBus,
                 messageEncoderFactory, userSettings, executorService, uri, profile,
                 backBufferFactory, userManager);

--- a/src/com/dmdirc/ServerFactoryImpl.java
+++ b/src/com/dmdirc/ServerFactoryImpl.java
@@ -46,7 +46,6 @@ import javax.inject.Singleton;
 @Singleton
 public class ServerFactoryImpl {
 
-    private final Provider<ServerManager> manager;
     private final ParserFactory parserFactory;
     private final TabCompleterFactory tabCompleterFactory;
     private final IdentityFactory identityFactory;
@@ -63,7 +62,6 @@ public class ServerFactoryImpl {
 
     @Inject
     public ServerFactoryImpl(
-            final Provider<ServerManager> manager,
             final ParserFactory parserFactory,
             final TabCompleterFactory tabCompleterFactory,
             final IdentityFactory identityFactory,
@@ -77,7 +75,6 @@ public class ServerFactoryImpl {
             @ClientModule.UserConfig final ConfigProvider userSettings,
             final BackBufferFactory backBufferFactory,
             final UserManager userManager) {
-        this.manager = manager;
         this.parserFactory = parserFactory;
         this.tabCompleterFactory = tabCompleterFactory;
         this.identityFactory = identityFactory;
@@ -99,7 +96,7 @@ public class ServerFactoryImpl {
             final ScheduledExecutorService executorService,
             final URI uri,
             final Profile profile) {
-        return new Server(manager.get(), configMigrator, commandParser, parserFactory,
+        return new Server(configMigrator, commandParser, parserFactory,
                 tabCompleterFactory, identityFactory, messageSinkManager, windowManager,
                 channelFactory.get(), queryFactory.get(), urlBuilder, eventBus,
                 messageEncoderFactory, userSettings, executorService, uri, profile,

--- a/test/com/dmdirc/ServerTest.java
+++ b/test/com/dmdirc/ServerTest.java
@@ -54,7 +54,6 @@ import static org.mockito.Mockito.when;
 
 public class ServerTest {
 
-    @Mock private ServerManager serverManager;
     @Mock private Profile profile;
     @Mock private AggregateConfigProvider configManager;
     @Mock private ConfigBinder configBinder;
@@ -89,7 +88,6 @@ public class ServerTest {
                 Matchers.<CommandType>anyVararg())).thenReturn(tabCompleter);
 
         server = new Server(
-                serverManager,
                 configMigrator,
                 commandParser,
                 parserFactory,

--- a/test/com/dmdirc/ServerTest.java
+++ b/test/com/dmdirc/ServerTest.java
@@ -31,7 +31,6 @@ import com.dmdirc.interfaces.config.AggregateConfigProvider;
 import com.dmdirc.interfaces.config.ConfigProvider;
 import com.dmdirc.interfaces.config.ConfigProviderMigrator;
 import com.dmdirc.interfaces.config.IdentityFactory;
-import com.dmdirc.ui.WindowManager;
 import com.dmdirc.ui.input.TabCompleter;
 import com.dmdirc.ui.input.TabCompleterFactory;
 import com.dmdirc.ui.messages.BackBufferFactory;
@@ -65,7 +64,6 @@ public class ServerTest {
     @Mock private TabCompleterFactory tabCompleterFactory;
     @Mock private TabCompleter tabCompleter;
     @Mock private MessageSinkManager messageSinkManager;
-    @Mock private WindowManager windowManager;
     @Mock private ChannelFactory channelFactory;
     @Mock private QueryFactory queryFactory;
     @Mock private URLBuilder urlBuilder;
@@ -94,7 +92,6 @@ public class ServerTest {
                 tabCompleterFactory,
                 identityFactory,
                 messageSinkManager,
-                windowManager,
                 channelFactory,
                 queryFactory,
                 urlBuilder,


### PR DESCRIPTION
SM now listens to frame closing events, so Server doesn't need
to hold on to a reference and inform it that it's closing.