### PR TITLE
Make MBassador only use 1 dispatcher/handler.

### DIFF
--- a/src/com/dmdirc/DMDircMBassador.java
+++ b/src/com/dmdirc/DMDircMBassador.java
@@ -36,8 +36,9 @@ public class DMDircMBassador extends MBassador<DMDircEvent> {
     public DMDircMBassador() {
         super(new BusConfiguration()
                 .addFeature(Feature.SyncPubSub.Default())
-                .addFeature(Feature.AsynchronousHandlerInvocation.Default())
-                .addFeature(Feature.AsynchronousMessageDispatch.Default()));
+                .addFeature(Feature.AsynchronousHandlerInvocation.Default(1, 1))
+                .addFeature(Feature.AsynchronousMessageDispatch.Default()
+                        .setNumberOfMessageDispatchers(1)));
     }
 
     public DMDircMBassador(final BusConfiguration configuration) {


### PR DESCRIPTION
We rely fairly heavily on events being ordered consistently, seems
like this is the only way to ensure that.