### PR TITLE
Copy GroupChat methods into a GroupChatManager.

### DIFF
--- a/src/com/dmdirc/Server.java
+++ b/src/com/dmdirc/Server.java
@@ -33,6 +33,7 @@ import com.dmdirc.events.ServerDisconnectedEvent;
 import com.dmdirc.events.ServerInviteExpiredEvent;
 import com.dmdirc.interfaces.Connection;
 import com.dmdirc.interfaces.GroupChat;
+import com.dmdirc.interfaces.GroupChatManager;
 import com.dmdirc.interfaces.User;
 import com.dmdirc.interfaces.config.ConfigChangeListener;
 import com.dmdirc.interfaces.config.ConfigProvider;
@@ -99,7 +100,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * The Server class represents the client's view of a server. It maintains a list of all channels,
  * queries, etc, and handles parser callbacks pertaining to the server.
  */
-public class Server extends FrameContainer implements Connection {
+public class Server extends FrameContainer implements Connection, GroupChatManager {
 
     private static final Logger LOG = LoggerFactory.getLogger(Server.class);
     /** The name of the general domain. */
@@ -1241,6 +1242,11 @@ public class Server extends FrameContainer implements Connection {
     @Override
     public int getMaxListModes(final char mode) {
         return getParser().map(p -> p.getMaxListModes(mode)).orElse(-1);
+    }
+
+    @Override
+    public GroupChatManager getGroupChatManager() {
+        return this;
     }
 
     /**

--- a/src/com/dmdirc/interfaces/Connection.java
+++ b/src/com/dmdirc/interfaces/Connection.java
@@ -495,4 +495,11 @@ public interface Connection {
      */
     int getMaxListModes(final char mode);
 
+    /**
+     * Gets the manager that handles this connection's group chats.
+     *
+     * @return The group chat manager for this connection.
+     */
+    GroupChatManager getGroupChatManager();
+
 }

--- a/src/com/dmdirc/interfaces/GroupChatManager.java
+++ b/src/com/dmdirc/interfaces/GroupChatManager.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2006-2015 DMDirc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.dmdirc.interfaces;
+
+import com.dmdirc.parser.common.ChannelJoinRequest;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * Handles all {@link GroupChat}s on a {@link Connection}
+ */
+public interface GroupChatManager {
+
+    /**
+     * Retrieves the specified channel belonging to this server.
+     *
+     * @param channel The channel to be retrieved
+     *
+     * @return The appropriate channel object
+     */
+    Optional<GroupChat> getChannel(final String channel);
+
+    /**
+     * Retrieves the possible channel prefixes in use on this server.
+     *
+     * @return This server's possible channel prefixes
+     */
+    String getChannelPrefixes();
+
+    /**
+     * Gets a collection of all channels on this connection.
+     *
+     * @return collection of channels belonging to this connection
+     */
+    Collection<GroupChat> getChannels();
+
+    /**
+     * Determines if the specified channel name is valid. A channel name is valid if we already have
+     * an existing Channel with the same name, or we have a valid parser instance and the parser
+     * says it's valid.
+     *
+     * @param channelName The name of the channel to test
+     *
+     * @return True if the channel name is valid, false otherwise
+     */
+    boolean isValidChannelName(final String channelName);
+
+    /**
+     * Attempts to join the specified channels. If channels with the same name already exist, they
+     * are (re)joined and their windows activated.
+     *
+     * @param requests The channel join requests to process
+     *
+     * @since 0.6.4
+     */
+    void join(final ChannelJoinRequest... requests);
+
+    /**
+     * Attempts to join the specified channels. If channels with the same name already exist, they
+     * are (re)joined.
+     *
+     * @param focus    Whether or not to focus any new channels
+     * @param requests The channel join requests to process
+     *
+     * @since 0.6.4
+     */
+    void join(final boolean focus, final ChannelJoinRequest... requests);
+
+}


### PR DESCRIPTION
Will remove them from Connection shortly. Then the functionality
can be pulled out of Server into a sane, separate class.