### PR TITLE
Fix away state dodgyness.

### DIFF
--- a/src/com/dmdirc/ServerEventHandler.java
+++ b/src/com/dmdirc/ServerEventHandler.java
@@ -358,16 +358,11 @@ public class ServerEventHandler extends EventHandler implements
 
         owner.updateAwayState(currentState == AwayState.AWAY ? Optional.of(reason) : Optional.empty());
 
-        if (oldState == AwayState.UNKNOWN) {
-            // Ignore discovered self away states
-            return;
-        }
-
         if (currentState == AwayState.AWAY) {
             final ServerAwayEvent event = new ServerAwayEvent(owner, reason);
             final String format = EventUtils.postDisplayable(eventBus, event, "away");
             owner.doNotification(format, reason);
-        } else {
+        } else if (oldState != AwayState.UNKNOWN) {
             final ServerBackEvent event = new ServerBackEvent(owner);
             final String format = EventUtils.postDisplayable(eventBus, event, "back");
             owner.doNotification(format);


### PR DESCRIPTION
Since changing to events we need to fire when changing from
unknown->away. Before, this was handled by the Server being
told about the new message (and then firing listeners).

Fixes #391.