### PR TITLE
Remove references to MessageTarget.

### DIFF
--- a/src/com/dmdirc/MessageTarget.java
+++ b/src/com/dmdirc/MessageTarget.java
@@ -23,6 +23,7 @@
 package com.dmdirc;
 
 import com.dmdirc.commandparser.parsers.CommandParser;
+import com.dmdirc.interfaces.Chat;
 import com.dmdirc.interfaces.config.AggregateConfigProvider;
 import com.dmdirc.ui.messages.BackBufferFactory;
 import com.dmdirc.ui.input.TabCompleter;
@@ -36,7 +37,7 @@ import javax.annotation.Nullable;
 /**
  * Defines common methods for objects that you can send messages to (such as channels and queries).
  */
-public abstract class MessageTarget extends FrameContainer {
+public abstract class MessageTarget extends FrameContainer implements Chat {
 
     /**
      * Creates a new MessageTarget.

--- a/src/com/dmdirc/Query.java
+++ b/src/com/dmdirc/Query.java
@@ -296,6 +296,11 @@ public class Query extends MessageTarget implements PrivateActionListener,
     }
 
     @Override
+    public FrameContainer getWindowModel() {
+        return this;
+    }
+
+    @Override
     public User getUser() {
         return user;
     }

--- a/src/com/dmdirc/commandparser/commands/chat/Me.java
+++ b/src/com/dmdirc/commandparser/commands/chat/Me.java
@@ -23,7 +23,6 @@
 package com.dmdirc.commandparser.commands.chat;
 
 import com.dmdirc.FrameContainer;
-import com.dmdirc.MessageTarget;
 import com.dmdirc.commandparser.BaseCommandInfo;
 import com.dmdirc.commandparser.CommandArguments;
 import com.dmdirc.commandparser.CommandInfo;
@@ -32,6 +31,7 @@ import com.dmdirc.commandparser.commands.Command;
 import com.dmdirc.commandparser.commands.ValidatingCommand;
 import com.dmdirc.commandparser.commands.context.ChatCommandContext;
 import com.dmdirc.commandparser.commands.context.CommandContext;
+import com.dmdirc.interfaces.Chat;
 import com.dmdirc.interfaces.CommandController;
 import com.dmdirc.interfaces.Connection;
 import com.dmdirc.util.validators.ValidationResponse;
@@ -62,7 +62,7 @@ public class Me extends Command implements ValidatingCommand {
     @Override
     public void execute(@Nonnull final FrameContainer origin,
             final CommandArguments args, final CommandContext context) {
-        final MessageTarget target = ((ChatCommandContext) context).getChat();
+        final Chat target = ((ChatCommandContext) context).getChat();
         if (args.getArguments().length == 0) {
             showUsage(origin, args.isSilent(), "me", "<action>");
         } else {

--- a/src/com/dmdirc/commandparser/commands/context/ChatCommandContext.java
+++ b/src/com/dmdirc/commandparser/commands/context/ChatCommandContext.java
@@ -23,8 +23,8 @@
 package com.dmdirc.commandparser.commands.context;
 
 import com.dmdirc.FrameContainer;
-import com.dmdirc.MessageTarget;
 import com.dmdirc.commandparser.CommandInfo;
+import com.dmdirc.interfaces.Chat;
 
 import java.util.Optional;
 
@@ -36,7 +36,7 @@ import java.util.Optional;
 public class ChatCommandContext extends ServerCommandContext {
 
     /** The chat container associated with this context. */
-    private final MessageTarget chat;
+    private final Chat chat;
 
     /**
      * Creates a new chat command context.
@@ -46,7 +46,7 @@ public class ChatCommandContext extends ServerCommandContext {
      * @param chat        The chat container associated with the command
      */
     public ChatCommandContext(final FrameContainer source,
-            final CommandInfo commandInfo, final MessageTarget chat) {
+            final CommandInfo commandInfo, final Chat chat) {
         super(source, commandInfo,
                 Optional.ofNullable(source)
                         .flatMap(FrameContainer::getConnection)
@@ -59,7 +59,7 @@ public class ChatCommandContext extends ServerCommandContext {
      *
      * @return This context's associated container
      */
-    public MessageTarget getChat() {
+    public Chat getChat() {
         return chat;
     }
 

--- a/src/com/dmdirc/commandparser/parsers/ChatCommandParser.java
+++ b/src/com/dmdirc/commandparser/parsers/ChatCommandParser.java
@@ -24,13 +24,13 @@ package com.dmdirc.commandparser.parsers;
 
 import com.dmdirc.DMDircMBassador;
 import com.dmdirc.FrameContainer;
-import com.dmdirc.MessageTarget;
 import com.dmdirc.commandparser.CommandArguments;
 import com.dmdirc.commandparser.CommandInfo;
 import com.dmdirc.commandparser.CommandType;
 import com.dmdirc.commandparser.commands.Command;
 import com.dmdirc.commandparser.commands.context.ChatCommandContext;
 import com.dmdirc.commandparser.commands.context.CommandContext;
+import com.dmdirc.interfaces.Chat;
 import com.dmdirc.interfaces.CommandController;
 
 import javax.annotation.Nonnull;
@@ -45,7 +45,7 @@ public class ChatCommandParser extends ServerCommandParser {
     /** A version number for this class. */
     private static final long serialVersionUID = 1;
     /** The container that owns this parser. */
-    private MessageTarget owner;
+    private Chat owner;
 
     /**
      * Creates a new chat command parser that belongs to a child of the specified server.
@@ -62,8 +62,8 @@ public class ChatCommandParser extends ServerCommandParser {
 
     @Override
     public void setOwner(final FrameContainer owner) {
-        if (this.owner == null) {
-            this.owner = (MessageTarget) owner;
+        if (this.owner == null && owner instanceof Chat) {
+            this.owner = (Chat) owner;
         }
     }
 

--- a/src/com/dmdirc/interfaces/Chat.java
+++ b/src/com/dmdirc/interfaces/Chat.java
@@ -22,6 +22,7 @@
 
 package com.dmdirc.interfaces;
 
+import com.dmdirc.FrameContainer;
 import com.dmdirc.parser.common.CompositionState;
 
 import java.util.Optional;
@@ -66,5 +67,12 @@ public interface Chat {
      * @param state The new composition state
      */
     void setCompositionState(final CompositionState state);
+
+    /**
+     * Gets the core model for the input/output window for this connection.
+     *
+     * @return A model for windows based on this connection.
+     */
+    FrameContainer getWindowModel();
 
 }

--- a/src/com/dmdirc/interfaces/GroupChat.java
+++ b/src/com/dmdirc/interfaces/GroupChat.java
@@ -23,7 +23,6 @@
 package com.dmdirc.interfaces;
 
 import com.dmdirc.DMDircMBassador;
-import com.dmdirc.FrameContainer;
 import com.dmdirc.Topic;
 
 import java.util.Collection;
@@ -117,13 +116,6 @@ public interface GroupChat extends Chat {
      * @return Users in the GroupChat
      */
     Collection<GroupChatUser> getUsers();
-
-    /**
-     * Gets the core model for the input/output window for this connection.
-     *
-     * @return A model for windows based on this connection.
-     */
-    FrameContainer getWindowModel();
 
     /**
      * Kicks the specified user, optionally with the specified message.

--- a/test/com/dmdirc/commandparser/commands/chat/MeTest.java
+++ b/test/com/dmdirc/commandparser/commands/chat/MeTest.java
@@ -21,9 +21,10 @@
  */
 package com.dmdirc.commandparser.commands.chat;
 
-import com.dmdirc.MessageTarget;
+import com.dmdirc.FrameContainer;
 import com.dmdirc.commandparser.CommandArguments;
 import com.dmdirc.commandparser.commands.context.ChatCommandContext;
+import com.dmdirc.interfaces.Chat;
 import com.dmdirc.interfaces.CommandController;
 
 import org.junit.Before;
@@ -32,33 +33,39 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyChar;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MeTest {
 
-    @Mock private MessageTarget mtt;
+    @Mock private Chat chat;
+    @Mock private FrameContainer frameContainer;
     @Mock private CommandController controller;
     private Me command;
 
     @Before
     public void setUp() {
+        when(chat.getWindowModel()).thenReturn(frameContainer);
         command = new Me(controller);
     }
 
     @Test
     public void testUsage() {
-        command.execute(mtt, new CommandArguments(controller, "/foo"),
-                new ChatCommandContext(null, Me.INFO, mtt));
+        command.execute(frameContainer, new CommandArguments(controller, "/foo"),
+                new ChatCommandContext(null, Me.INFO, chat));
 
-        verify(mtt).addLine(eq("commandUsage"), anyChar(), anyString(), anyString());
+        verify(frameContainer).addLine(eq("commandUsage"), anyChar(), anyString(), anyString());
     }
 
     @Test
     public void testSend() {
         command.execute(null, new CommandArguments(controller, "/foo hello meep moop"),
-                new ChatCommandContext(null, Me.INFO, mtt));
+                new ChatCommandContext(null, Me.INFO, chat));
 
-        verify(mtt).sendAction("hello meep moop");
+        verify(chat).sendAction("hello meep moop");
     }
 }


### PR DESCRIPTION
Doesn't make sense to have this any more, as Chat provides the
common interface between queries + channels.