### PR TITLE
Split up client build file.

### DIFF
--- a/analysis.gradle
+++ b/analysis.gradle
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2006-2015 DMDirc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+dependencies {
+    pmd group: 'net.sourceforge.pmd', name: 'pmd-core', version: '5.2.3'
+    pmd group: 'net.sourceforge.pmd', name: 'pmd-java', version: '5.2.3'
+}
+
+pmd {
+    ruleSets = []
+    ruleSetFiles = files("$rootDir/etc/pmd/full.xml")
+    toolVersion = '5.2.3'
+    ignoreFailures = true
+}
+
+tasks.withType(FindBugs) {
+    reports {
+        html.enabled = true
+        xml.enabled = false
+    }
+}
+
+findbugs {
+    reportLevel = 'low'
+    effort = 'max'
+    ignoreFailures = true
+}

--- a/build.gradle
+++ b/build.gradle
@@ -12,10 +12,6 @@ apply plugin: 'pmd'
 configurations {
     bundle
 
-    plugin {
-        transitive = false
-    }
-
     compile {
         extendsFrom bundle
     }
@@ -40,34 +36,9 @@ dependencies {
     bundle group: 'com.dmdirc', name: 'util', version: '+', changing: true
     bundle group: 'com.dmdirc.parser', name: 'common', version: '+', changing: true
 
-    plugin group: 'com.dmdirc', name: 'ui_swing', version: '+', changing: true
-    plugin group: 'com.dmdirc', name: 'parser_irc', version: '+', changing: true
-    plugin group: 'com.dmdirc', name: 'tabcompletion_bash', version: '+', changing: true
-    plugin group: 'com.dmdirc', name: 'tabcompletion_mirc', version: '+', changing: true
-
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.mockito', name: 'mockito-all', version: '1.10.17'
     testCompile group: 'com.google.jimfs', name: 'jimfs', version: '1.0'
-
-    pmd group: 'net.sourceforge.pmd', name: 'pmd-core', version: '5.2.3'
-    pmd group: 'net.sourceforge.pmd', name: 'pmd-java', version: '5.2.3'
-}
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            groupId 'com.dmdirc'
-            artifactId 'client'
-
-            artifact jar
-        }
-    }
-    repositories {
-        maven {
-            name 'snapshots'
-            url 'http://artifactory.dmdirc.com/artifactory/repo'
-        }
-    }
 }
 
 sourceSets {
@@ -91,124 +62,10 @@ repositories {
     }
 }
 
-pmd {
-    ruleSets = []
-    ruleSetFiles = files("$rootDir/etc/pmd/full.xml")
-    toolVersion = '5.2.3'
-    ignoreFailures = true
-}
-
-tasks.withType(FindBugs) {
-    reports {
-        html.enabled = true
-        xml.enabled = false
-    }
-}
-
-findbugs {
-    reportLevel = 'low'
-    effort = 'max'
-    ignoreFailures = true
-}
-
-task publishSnapshot(dependsOn: 'publishMavenJavaPublicationToSnapshotsRepository') << {
-}
-
-task createVersionConfig {
-    inputs.dir 'src'
-    inputs.dir 'res'
-    outputs.file new File(buildDir, 'version.config')
-    dependsOn classes
-
-    doLast {
-        def targetFile = new File(buildDir, 'version.config')
-
-        targetFile.text = ''
-        targetFile << "keysections:\n identity\n version\n updater\n bundledplugins_versions\n\n"
-        targetFile << "identity:\n name=DMDirc version information\n globaldefault=true\n order=95000\n\n"
-        targetFile << "version:\n version=${version}\n\n"
-        targetFile << "updater:\n channel=${updaterChannel}\n\n"
-        targetFile << "buildenv:\n"
-        def compileConfiguration = project.configurations.getByName("compile")
-        def resolvedConfiguration = compileConfiguration.resolvedConfiguration
-        def resolvedArtifacts = resolvedConfiguration.resolvedArtifacts
-        resolvedArtifacts.each { dp ->
-            def version = dp.moduleVersion.id
-            targetFile << " " + version.group + " " + version.name + " " + version.version + "\n"
-        }
-    }
-}
-
-task createFatVersionConfig {
-    inputs.file new File(buildDir, 'version.config')
-    outputs.file new File(buildDir, 'fat.version.config')
-    dependsOn createVersionConfig
-
-    doLast {
-        def sourceFile = new File(buildDir, 'version.config')
-        def targetFile = new File(buildDir, 'fat.version.config')
-
-        java.nio.file.Files.copy(sourceFile.toPath(), targetFile.toPath(),
-            java.nio.file.StandardCopyOption.REPLACE_EXISTING)
-
-        targetFile << "\nbundledplugins_versions:\n"
-        configurations.plugin.each { p ->
-            targetFile << " " + p.name.replaceFirst('-', '=').replaceAll('.jar$', '\n');
-        }
-    }
-}
-
-test.dependsOn createVersionConfig
-
-jar {
-    outputs.file "dist/DMDirc.jar"
-    dependsOn createVersionConfig
-
-    exclude 'com/dmdirc/version.config'
-
-    from("$buildDir/version.config") {
-        into 'com/dmdirc/'
-    }
-
-    from { configurations.bundle.collect { it.isDirectory() ? it : zipTree(it) } } {
-        exclude 'META-INF/**'
-    }
-
-    manifest {
-        attributes 'Main-Class': 'com.dmdirc.Main'
-    }
-
-    doLast {
-        copy {
-            from jar.archivePath
-            into "dist/"
-            rename ".*", "DMDirc.jar"
-        }
-    }
-}
-
-task('fatjar', type: Jar) {
-    dependsOn createFatVersionConfig
-    baseName = 'fat-client'
-
-    from("$buildDir/fat.version.config") {
-        into 'com/dmdirc'
-        rename 'fat.version.config', 'version.config'
-    }
-
-    into('plugins') {
-        from configurations.plugin
-        rename '(.*?)-.*(\\.jar)', '$1$2'
-    }
-
-    with jar {
-        exclude 'com/dmdirc/version.config'
-    }
-
-    manifest {
-        attributes 'Main-Class': 'com.dmdirc.Main'
-    }
-}
+apply from: 'analysis.gradle'
+apply from: 'publishing.gradle'
+apply from: 'jar.gradle'
+apply from: 'fatjar.gradle'
 
 buildscript {
     repositories {

--- a/fatjar.gradle
+++ b/fatjar.gradle
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2006-2015 DMDirc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+configurations {
+    plugin {
+        transitive = false
+    }
+}
+
+dependencies {
+    plugin group: 'com.dmdirc', name: 'ui_swing', version: '+', changing: true
+    plugin group: 'com.dmdirc', name: 'parser_irc', version: '+', changing: true
+    plugin group: 'com.dmdirc', name: 'tabcompletion_bash', version: '+', changing: true
+    plugin group: 'com.dmdirc', name: 'tabcompletion_mirc', version: '+', changing: true
+}
+
+task createFatVersionConfig {
+    inputs.file new File(buildDir, 'version.config')
+    outputs.file new File(buildDir, 'fat.version.config')
+    dependsOn createVersionConfig
+
+    doLast {
+        def sourceFile = new File(buildDir, 'version.config')
+        def targetFile = new File(buildDir, 'fat.version.config')
+
+        java.nio.file.Files.copy(sourceFile.toPath(), targetFile.toPath(),
+                java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+
+        targetFile << "\nbundledplugins_versions:\n"
+        configurations.plugin.each { p ->
+            targetFile << " " + p.name.replaceFirst('-', '=').replaceAll('.jar$', '\n');
+        }
+    }
+}
+
+task('fatjar', type: Jar) {
+    dependsOn createFatVersionConfig
+    baseName = 'fat-client'
+
+    from("$buildDir/fat.version.config") {
+        into 'com/dmdirc'
+        rename 'fat.version.config', 'version.config'
+    }
+
+    into('plugins') {
+        from configurations.plugin
+        rename '(.*?)-.*(\\.jar)', '$1$2'
+    }
+
+    with jar {
+        exclude 'com/dmdirc/version.config'
+    }
+
+    manifest {
+        attributes 'Main-Class': 'com.dmdirc.Main'
+    }
+}

--- a/jar.gradle
+++ b/jar.gradle
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2006-2015 DMDirc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+task createVersionConfig {
+    inputs.dir 'src'
+    inputs.dir 'res'
+    outputs.file new File(buildDir, 'version.config')
+    dependsOn classes
+
+    doLast {
+        def targetFile = new File(buildDir, 'version.config')
+
+        targetFile.text = ''
+        targetFile << "keysections:\n identity\n version\n updater\n bundledplugins_versions\n\n"
+        targetFile << "identity:\n name=DMDirc version information\n globaldefault=true\n order=95000\n\n"
+        targetFile << "version:\n version=${version}\n\n"
+        targetFile << "updater:\n channel=${updaterChannel}\n\n"
+        targetFile << "buildenv:\n"
+        def compileConfiguration = project.configurations.getByName("compile")
+        def resolvedConfiguration = compileConfiguration.resolvedConfiguration
+        def resolvedArtifacts = resolvedConfiguration.resolvedArtifacts
+        resolvedArtifacts.each { dp ->
+            def version = dp.moduleVersion.id
+            targetFile << " " + version.group + " " + version.name + " " + version.version + "\n"
+        }
+    }
+}
+
+jar {
+    outputs.file "dist/DMDirc.jar"
+    dependsOn createVersionConfig
+
+    exclude 'com/dmdirc/version.config'
+
+    from("$buildDir/version.config") {
+        into 'com/dmdirc/'
+    }
+
+    from { configurations.bundle.collect { it.isDirectory() ? it : zipTree(it) } } {
+        exclude 'META-INF/**'
+    }
+
+    manifest {
+        attributes 'Main-Class': 'com.dmdirc.Main'
+    }
+
+    doLast {
+        copy {
+            from jar.archivePath
+            into "dist/"
+            rename ".*", "DMDirc.jar"
+        }
+    }
+}

--- a/publishing.gradle
+++ b/publishing.gradle
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2006-2015 DMDirc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            groupId 'com.dmdirc'
+            artifactId 'client'
+
+            artifact jar
+        }
+    }
+    repositories {
+        maven {
+            name 'snapshots'
+            url 'http://artifactory.dmdirc.com/artifactory/repo'
+        }
+    }
+}
+
+task publishSnapshot(dependsOn: 'publishMavenJavaPublicationToSnapshotsRepository') << {
+}


### PR DESCRIPTION
Makes it a bit less messy, and easier to find the right bits.