### PR TITLE
Remove PluginMetaData.getManager().

### DIFF
--- a/src/com/dmdirc/plugins/PluginMetaData.java
+++ b/src/com/dmdirc/plugins/PluginMetaData.java
@@ -358,16 +358,6 @@ public class PluginMetaData {
     }
 
     // <editor-fold defaultstate="collapsed" desc="Getters">
-    /**
-     * What plugin manager owns this metadata?
-     *
-     * @return The pluginmanager that created this metadata.
-     * @deprecated Callers should obtain a reference to the PluginManager independently.
-     */
-    @Deprecated
-    public PluginManager getManager() {
-        return manager;
-    }
 
     /**
      * Retrieves the URL to the plugin that this metadata corresponds to.

--- a/src/com/dmdirc/plugins/implementations/PluginFilesHelper.java
+++ b/src/com/dmdirc/plugins/implementations/PluginFilesHelper.java
@@ -23,6 +23,7 @@
 package com.dmdirc.plugins.implementations;
 
 import com.dmdirc.plugins.PluginInfo;
+import com.dmdirc.plugins.PluginManager;
 import com.dmdirc.plugins.PluginMetaData;
 
 import java.io.File;
@@ -41,6 +42,8 @@ public class PluginFilesHelper {
 
     /** This plugins meta data object. */
     private final PluginMetaData metaData;
+    /** Plugin manager to use to get directory. */
+    private final PluginManager pluginManager;
     /** This plugins information object. */
     private final PluginInfo pluginInfo;
     /** This plugins files directory. */
@@ -49,9 +52,11 @@ public class PluginFilesHelper {
     /**
      * Creates a new instance of this helper
      *
+     * @param pluginManager Plugin manager to use to get directory
      * @param pluginInfo This plugin's information object
      */
-    public PluginFilesHelper(final PluginInfo pluginInfo) {
+    public PluginFilesHelper(final PluginManager pluginManager, final PluginInfo pluginInfo) {
+        this.pluginManager = pluginManager;
         this.pluginInfo = pluginInfo;
         this.metaData = pluginInfo.getMetaData();
         filesDir = initFilesDir();
@@ -70,7 +75,7 @@ public class PluginFilesHelper {
     private File initFilesDir() {
         if (filesDir == null) {
             final String fs = System.getProperty("file.separator");
-            final String dir = metaData.getManager().getFilesDirectory();
+            final String dir = pluginManager.getFilesDirectory();
             filesDir = new File(dir + metaData.getName() + fs);
             if (!filesDir.exists()) {
                 filesDir.mkdirs();

--- a/test/com/dmdirc/ui/messages/HighlightManagerTest.java
+++ b/test/com/dmdirc/ui/messages/HighlightManagerTest.java
@@ -34,6 +34,8 @@ import com.dmdirc.interfaces.GroupChatUser;
 import com.dmdirc.interfaces.User;
 import com.dmdirc.interfaces.config.AggregateConfigProvider;
 
+import com.google.common.collect.Lists;
+
 import java.util.Collections;
 import java.util.Optional;
 
@@ -43,8 +45,6 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import autovalue.shaded.com.google.common.common.collect.Lists;
 
 import static org.junit.Assert.assertSame;
 import static org.mockito.Matchers.any;


### PR DESCRIPTION
This is horribly icky and wrong. The only place it's used is
PluginFilesHelper, which can easily be given its own manager.

Also fix annoying shaded import.