### PR TITLE
Make the IconManager injectable using a global config.

### DIFF
--- a/src/com/dmdirc/ui/IconManager.java
+++ b/src/com/dmdirc/ui/IconManager.java
@@ -36,6 +36,7 @@ import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
@@ -64,6 +65,7 @@ public class IconManager implements ConfigChangeListener {
      * @param configManager Config manager to retrieve settings from
      * @param urlBuilder    URL builder to use for icons.
      */
+    @Inject
     public IconManager(
             @GlobalConfig final AggregateConfigProvider configManager,
             final URLBuilder urlBuilder) {

--- a/src/com/dmdirc/ui/IconManager.java
+++ b/src/com/dmdirc/ui/IconManager.java
@@ -36,13 +36,17 @@ import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.inject.Singleton;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
+
+import static com.dmdirc.ClientModule.GlobalConfig;
 
 /**
  * The icon manager provides a standard way to access icons for use in DMDirc. It allows the user to
  * override the default actions using config settings under the icons domain.
  */
+@Singleton
 public class IconManager implements ConfigChangeListener {
 
     /** A map of existing icons. */
@@ -61,7 +65,7 @@ public class IconManager implements ConfigChangeListener {
      * @param urlBuilder    URL builder to use for icons.
      */
     public IconManager(
-            final AggregateConfigProvider configManager,
+            @GlobalConfig final AggregateConfigProvider configManager,
             final URLBuilder urlBuilder) {
         this.configManager = configManager;
         this.urlBuilder = urlBuilder;


### PR DESCRIPTION
I'm planning on removing scoped IconManagers - it's a lot of effort
to maintain them and pass them in everywhere (instead of injecting
them) for almost no gain. I don't think we've ever set a per-server
or per-channel icon, and I can't imagine why we'd want to.