### PR TITLE
Add hints to tell idea where generated sources are

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,15 @@ apply plugin: 'maven-publish'
 apply plugin: 'java'
 apply plugin: 'findbugs'
 apply plugin: 'pmd'
+apply plugin: 'idea'
+
+idea {
+    module {
+         sourceDirs = [file('src'), file('generated')]
+         testSourceDirs = [file('test'), file('generated_tests')]
+         generatedSourceDirs = [file('generated'), file('generated_tests')]
+    }
+}
 
 configurations {
     bundle


### PR DESCRIPTION
This doesn't seem to actually mark them as generated, but they're
marked as source/test dirs which stops the annoying errors every
time you sync.