### PR TITLE
Bump raven to 6.0.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     bundle group: 'com.squareup.dagger', name: 'dagger', version: '1.2.1'
     bundle group: 'com.esotericsoftware.yamlbeans', name: 'yamlbeans', version: '1.08'
     bundle group: 'com.brsanthu', name: 'migbase64', version: '2.2'
-    bundle group: 'net.kencochrane.raven', name: 'raven', version: '5.0.1'
+    bundle group: 'net.kencochrane.raven', name: 'raven', version: '6.0.0'
     bundle group: 'com.google.guava', name:'guava', version: '18.0'
     bundle group: 'net.engio', name: 'mbassador', version: '1.2.0'
     bundle group: 'com.dmdirc', name: 'util', version: '+', changing: true


### PR DESCRIPTION
No major changes, just a version bump for the Sentry protocol
(for Sentry 7) and removal of UDP connections which we never
used.