### PR TITLE
Remove Query.getHost.

### DIFF
--- a/src/com/dmdirc/Query.java
+++ b/src/com/dmdirc/Query.java
@@ -136,8 +136,11 @@ public class Query extends FrameContainer implements PrivateActionListener,
 
     @Override
     public int getMaxLineLength() {
+        // TODO: The parser layer should abstract this
         return connection.getState() == ServerState.CONNECTED ? connection.getParser().get()
-                .getMaxLength("PRIVMSG", getHost()) : -1;
+                .getMaxLength("PRIVMSG", user.getNickname()
+                        + '!' + user.getUsername().orElse("")
+                        + '@' + user.getHostname().orElse("")) : -1;
     }
 
     @Override
@@ -147,7 +150,7 @@ public class Query extends FrameContainer implements PrivateActionListener,
             return;
         }
 
-        final int maxLineLength = connection.getParser().get().getMaxLength("PRIVMSG", getHost());
+        final int maxLineLength = getMaxLineLength();
 
         if (maxLineLength >= action.length() + 2) {
             connection.getParser().get().sendAction(getNickname(), action);
@@ -268,21 +271,13 @@ public class Query extends FrameContainer implements PrivateActionListener,
     }
 
     @Override
-    public String getHost() {
-        // TODO: Icky, IRC specific. Kill with fire.
-        return user.getNickname()
-                + '!' + user.getUsername().orElse("")
-                + '@' + user.getHostname().orElse("");
-    }
-
-    @Override
     public String getNickname() {
         return user.getNickname();
     }
 
     @Override
     public void setCompositionState(final CompositionState state) {
-        connection.getParser().get().setCompositionState(getHost(), state);
+        connection.getParser().get().setCompositionState(user.getNickname(), state);
     }
 
     @Override

--- a/src/com/dmdirc/interfaces/PrivateChat.java
+++ b/src/com/dmdirc/interfaces/PrivateChat.java
@@ -28,13 +28,6 @@ package com.dmdirc.interfaces;
 public interface PrivateChat extends Chat {
 
     /**
-     * Returns the host that this query is with.
-     *
-     * @return The full host that this query is with
-     */
-    String getHost();
-
-    /**
      * Returns the current nickname of the user that this query is with.
      *
      * @return The nickname of this query's user


### PR DESCRIPTION
Only one place in the core needs the silly IRC format, so just
inline it there.