### PR TITLE
Make Chat return a WindowModel.

### DIFF
--- a/src/com/dmdirc/MessageEncoder.java
+++ b/src/com/dmdirc/MessageEncoder.java
@@ -25,6 +25,7 @@ package com.dmdirc;
 import com.dmdirc.events.UserErrorEvent;
 import com.dmdirc.interfaces.Connection;
 import com.dmdirc.interfaces.GroupChat;
+import com.dmdirc.interfaces.WindowModel;
 import com.dmdirc.logger.ErrorLevel;
 import com.dmdirc.parser.interfaces.Encoder;
 import com.dmdirc.parser.interfaces.Parser;
@@ -67,7 +68,7 @@ public class MessageEncoder implements Encoder {
         if (target != null && parser.isValidChannelName(target)) {
             encoding = connection.getGroupChatManager().getChannel(target)
                     .map(GroupChat::getWindowModel)
-                    .map(FrameContainer::getConfigManager)
+                    .map(WindowModel::getConfigManager)
                     .map(cm -> cm.getOption("general", "encoding"))
                     .orElse(encoding);
         }

--- a/src/com/dmdirc/commandparser/commands/server/AllChannels.java
+++ b/src/com/dmdirc/commandparser/commands/server/AllChannels.java
@@ -71,7 +71,8 @@ public class AllChannels extends Command implements IntelligentCommand {
         final String command = args.getArgumentsAsString();
 
         for (GroupChat channel : server.getGroupChatManager().getChannels()) {
-            channel.getWindowModel().getCommandParser().parseCommand(channel.getWindowModel(),
+            channel.getWindowModel().getCommandParser().parseCommand(
+                    (FrameContainer) channel.getWindowModel(),
                     command);
         }
     }

--- a/src/com/dmdirc/events/ChannelDisplayableEvent.java
+++ b/src/com/dmdirc/events/ChannelDisplayableEvent.java
@@ -73,7 +73,7 @@ public abstract class ChannelDisplayableEvent extends ChannelEvent implements Di
 
     @Override
     public FrameContainer getSource() {
-        return getChannel().getWindowModel();
+        return (FrameContainer) getChannel().getWindowModel();
     }
 
 }

--- a/src/com/dmdirc/interfaces/Chat.java
+++ b/src/com/dmdirc/interfaces/Chat.java
@@ -22,7 +22,6 @@
 
 package com.dmdirc.interfaces;
 
-import com.dmdirc.FrameContainer;
 import com.dmdirc.parser.common.CompositionState;
 
 import java.util.Optional;
@@ -73,6 +72,6 @@ public interface Chat {
      *
      * @return A model for windows based on this connection.
      */
-    FrameContainer getWindowModel();
+    WindowModel getWindowModel();
 
 }


### PR DESCRIPTION
Start to move FrameContainers behind an iface so they can be
pulled out.

For now, just cast back when needed.