### PR TITLE
Tidy how CommandParsers are created.

### DIFF
--- a/src/com/dmdirc/Channel.java
+++ b/src/com/dmdirc/Channel.java
@@ -23,7 +23,6 @@
 package com.dmdirc;
 
 import com.dmdirc.commandparser.CommandType;
-import com.dmdirc.commandparser.parsers.ChannelCommandParser;
 import com.dmdirc.config.ConfigBinding;
 import com.dmdirc.events.ChannelClosedEvent;
 import com.dmdirc.events.ChannelSelfActionEvent;
@@ -35,7 +34,6 @@ import com.dmdirc.events.NickListClientAddedEvent;
 import com.dmdirc.events.NickListClientRemovedEvent;
 import com.dmdirc.events.NickListClientsChangedEvent;
 import com.dmdirc.events.NickListUpdatedEvent;
-import com.dmdirc.interfaces.CommandController;
 import com.dmdirc.interfaces.Connection;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
@@ -103,18 +101,14 @@ public class Channel extends FrameContainer implements GroupChat {
      * @param newChannelInfo      The parser's channel object that corresponds to this channel
      * @param configMigrator      The config migrator which provides the config for this channel.
      * @param tabCompleterFactory The factory to use to create tab completers.
-     * @param commandController   The controller to load commands from.
      * @param messageSinkManager  The sink manager to use to despatch messages.
-     * @param eventBus            The bus to despatch events onto.
      */
     public Channel(
             final Connection connection,
             final ChannelInfo newChannelInfo,
             final ConfigProviderMigrator configMigrator,
             final TabCompleterFactory tabCompleterFactory,
-            final CommandController commandController,
             final MessageSinkManager messageSinkManager,
-            final DMDircMBassador eventBus,
             final BackBufferFactory backBufferFactory,
             final GroupChatUserManager groupChatUserManager) {
         super(connection.getWindowModel(), "channel-inactive",
@@ -122,7 +116,6 @@ public class Channel extends FrameContainer implements GroupChat {
                 Styliser.stipControlCodes(newChannelInfo.getName()),
                 configMigrator.getConfigProvider(),
                 backBufferFactory,
-                new ChannelCommandParser(connection.getWindowModel(), commandController,  eventBus),
                 tabCompleterFactory.getTabCompleter(connection.getWindowModel().getTabCompleter(),
                         configMigrator.getConfigProvider(), CommandType.TYPE_CHANNEL,
                         CommandType.TYPE_CHAT),

--- a/src/com/dmdirc/ChannelFactory.java
+++ b/src/com/dmdirc/ChannelFactory.java
@@ -22,6 +22,7 @@
 
 package com.dmdirc;
 
+import com.dmdirc.commandparser.parsers.ChannelCommandParser;
 import com.dmdirc.events.ChannelOpenedEvent;
 import com.dmdirc.interfaces.CommandController;
 import com.dmdirc.interfaces.Connection;
@@ -67,8 +68,9 @@ public class ChannelFactory {
             final ChannelInfo channelInfo,
             final ConfigProviderMigrator configMigrator) {
         final Channel channel = new Channel(connection, channelInfo, configMigrator,
-                tabCompleterFactory, commandController, messageSinkManager, eventBus,
-                backBufferFactory, groupChatUserManager);
+                tabCompleterFactory, messageSinkManager, backBufferFactory, groupChatUserManager);
+        channel.setCommandParser(new ChannelCommandParser(connection.getWindowModel(),
+                commandController, eventBus, channel));
         windowManager.addWindow(connection.getWindowModel(), channel);
         connection.getWindowModel().getEventBus().publish(new ChannelOpenedEvent(channel));
         return channel;

--- a/src/com/dmdirc/FrameContainer.java
+++ b/src/com/dmdirc/FrameContainer.java
@@ -96,12 +96,6 @@ public abstract class FrameContainer implements WindowModel {
     private BackBuffer backBuffer;
 
     /**
-     * The command parser used for commands in this container.
-     * <p>
-     * Only defined if this container is {@link #writable}.
-     */
-    private final Optional<CommandParser> commandParser;
-    /**
      * The manager to use to dispatch messages to sinks.
      * <p>
      * Only defined if this container is {@link #writable}.
@@ -113,6 +107,13 @@ public abstract class FrameContainer implements WindowModel {
      * Only defined if this container is {@link #writable}.
      */
     private final Optional<TabCompleter> tabCompleter;
+
+    /**
+     * The command parser used for commands in this container.
+     * <p>
+     * Only defined if this container is {@link #writable}.
+     */
+    private Optional<CommandParser> commandParser = Optional.empty();
 
     /**
      * Instantiate new frame container.
@@ -132,7 +133,6 @@ public abstract class FrameContainer implements WindowModel {
         this.title = title;
         this.components = new HashSet<>(components);
         this.writable = false;
-        this.commandParser = Optional.empty();
         this.tabCompleter = Optional.empty();
         this.messageSinkManager = Optional.empty();
         this.backBufferFactory = backBufferFactory;
@@ -157,7 +157,6 @@ public abstract class FrameContainer implements WindowModel {
             final String title,
             final AggregateConfigProvider config,
             final BackBufferFactory backBufferFactory,
-            final CommandParser commandParser,
             final TabCompleter tabCompleter,
             final MessageSinkManager messageSinkManager,
             final DMDircMBassador eventBus,
@@ -168,11 +167,9 @@ public abstract class FrameContainer implements WindowModel {
         this.title = title;
         this.components = new HashSet<>(components);
         this.writable = true;
-        this.commandParser = Optional.of(commandParser);
         this.tabCompleter = Optional.of(tabCompleter);
         this.messageSinkManager = Optional.of(messageSinkManager);
         this.backBufferFactory = backBufferFactory;
-        commandParser.setOwner(this);
 
         eventBusManager = new ChildEventBusManager(eventBus);
         eventBusManager.connect();
@@ -187,6 +184,10 @@ public abstract class FrameContainer implements WindowModel {
     protected void initBackBuffer() {
         backBuffer = backBufferFactory.getBackBuffer(this);
         backBuffer.startAddingEvents();
+    }
+
+    public void setCommandParser(final CommandParser commandParser) {
+        this.commandParser = Optional.ofNullable(commandParser);
     }
 
     @Override

--- a/src/com/dmdirc/GlobalWindow.java
+++ b/src/com/dmdirc/GlobalWindow.java
@@ -56,12 +56,13 @@ public class GlobalWindow extends FrameContainer {
             final GlobalCommandParser parser, final TabCompleterFactory tabCompleterFactory,
             final MessageSinkManager messageSinkManager,
             final DMDircMBassador eventBus, final BackBufferFactory backBufferFactory) {
-        super(null, "icon", "Global", "(Global)", config, backBufferFactory, parser,
+        super(null, "icon", "Global", "(Global)", config, backBufferFactory,
                 tabCompleterFactory.getTabCompleter(config, CommandType.TYPE_GLOBAL),
                 messageSinkManager, eventBus,
                 Arrays.asList(WindowComponent.TEXTAREA.getIdentifier(),
                         WindowComponent.INPUTFIELD.getIdentifier()));
         initBackBuffer();
+        setCommandParser(parser);
     }
 
     @Override

--- a/src/com/dmdirc/Query.java
+++ b/src/com/dmdirc/Query.java
@@ -23,7 +23,6 @@
 package com.dmdirc;
 
 import com.dmdirc.commandparser.CommandType;
-import com.dmdirc.commandparser.parsers.QueryCommandParser;
 import com.dmdirc.events.AppErrorEvent;
 import com.dmdirc.events.CommandErrorEvent;
 import com.dmdirc.events.QueryActionEvent;
@@ -33,7 +32,6 @@ import com.dmdirc.events.QueryNickChangeEvent;
 import com.dmdirc.events.QueryQuitEvent;
 import com.dmdirc.events.QuerySelfActionEvent;
 import com.dmdirc.events.QuerySelfMessageEvent;
-import com.dmdirc.interfaces.CommandController;
 import com.dmdirc.interfaces.Connection;
 import com.dmdirc.interfaces.PrivateChat;
 import com.dmdirc.interfaces.User;
@@ -78,7 +76,6 @@ public class Query extends FrameContainer implements PrivateActionListener,
             final Connection connection,
             final User user,
             final TabCompleterFactory tabCompleterFactory,
-            final CommandController commandController,
             final MessageSinkManager messageSinkManager,
             final BackBufferFactory backBufferFactory) {
         super(connection.getWindowModel(), "query",
@@ -86,8 +83,6 @@ public class Query extends FrameContainer implements PrivateActionListener,
                 user.getNickname(),
                 connection.getWindowModel().getConfigManager(),
                 backBufferFactory,
-                new QueryCommandParser(connection.getWindowModel(),
-                        commandController, connection.getWindowModel().getEventBus()),
                 tabCompleterFactory.getTabCompleter(connection.getWindowModel().getTabCompleter(),
                         connection.getWindowModel().getConfigManager(),
                         CommandType.TYPE_QUERY, CommandType.TYPE_CHAT),

--- a/src/com/dmdirc/QueryFactory.java
+++ b/src/com/dmdirc/QueryFactory.java
@@ -22,6 +22,7 @@
 
 package com.dmdirc;
 
+import com.dmdirc.commandparser.parsers.QueryCommandParser;
 import com.dmdirc.events.QueryOpenedEvent;
 import com.dmdirc.interfaces.CommandController;
 import com.dmdirc.interfaces.Connection;
@@ -58,8 +59,10 @@ public class QueryFactory {
     }
 
     public Query getQuery(final Connection connection, final User user) {
-        final Query query = new Query(connection, user, tabCompleterFactory, commandController,
+        final Query query = new Query(connection, user, tabCompleterFactory,
                 messageSinkManager, backBufferFactory);
+        query.setCommandParser(new QueryCommandParser(connection.getWindowModel(),
+                commandController, connection.getWindowModel().getEventBus(), query));
         windowManager.addWindow(connection.getWindowModel(), query);
         connection.getWindowModel().getEventBus().publish(new QueryOpenedEvent(query));
         return query;

--- a/src/com/dmdirc/Server.java
+++ b/src/com/dmdirc/Server.java
@@ -23,7 +23,6 @@
 package com.dmdirc;
 
 import com.dmdirc.commandparser.CommandType;
-import com.dmdirc.commandparser.parsers.CommandParser;
 import com.dmdirc.config.profiles.Profile;
 import com.dmdirc.events.AppErrorEvent;
 import com.dmdirc.events.ServerConnectErrorEvent;
@@ -177,7 +176,6 @@ public class Server extends FrameContainer implements Connection {
      */
     public Server(
             final ConfigProviderMigrator configMigrator,
-            final CommandParser commandParser,
             final ParserFactory parserFactory,
             final TabCompleterFactory tabCompleterFactory,
             final IdentityFactory identityFactory,
@@ -197,7 +195,6 @@ public class Server extends FrameContainer implements Connection {
                 getHost(uri),
                 configMigrator.getConfigProvider(),
                 backBufferFactory,
-                commandParser,
                 tabCompleterFactory.getTabCompleter(configMigrator.getConfigProvider(),
                         CommandType.TYPE_SERVER, CommandType.TYPE_GLOBAL),
                 messageSinkManager,

--- a/src/com/dmdirc/ServerFactoryImpl.java
+++ b/src/com/dmdirc/ServerFactoryImpl.java
@@ -22,8 +22,9 @@
 
 package com.dmdirc;
 
-import com.dmdirc.commandparser.parsers.CommandParser;
+import com.dmdirc.commandparser.parsers.ServerCommandParser;
 import com.dmdirc.config.profiles.Profile;
+import com.dmdirc.interfaces.CommandController;
 import com.dmdirc.interfaces.config.ConfigProvider;
 import com.dmdirc.interfaces.config.ConfigProviderMigrator;
 import com.dmdirc.interfaces.config.IdentityFactory;
@@ -49,6 +50,7 @@ public class ServerFactoryImpl {
     private final IdentityFactory identityFactory;
     private final MessageSinkManager messageSinkManager;
     private final Provider<QueryFactory> queryFactory;
+    private final Provider<CommandController> commandController;
     private final DMDircMBassador eventBus;
     private final MessageEncoderFactory messageEncoderFactory;
     private final ConfigProvider userSettings;
@@ -63,6 +65,7 @@ public class ServerFactoryImpl {
             final IdentityFactory identityFactory,
             final MessageSinkManager messageSinkManager,
             final Provider<QueryFactory> queryFactory,
+            final Provider<CommandController> commandController,
             final DMDircMBassador eventBus,
             final MessageEncoderFactory messageEncoderFactory,
             @ClientModule.UserConfig final ConfigProvider userSettings,
@@ -74,6 +77,7 @@ public class ServerFactoryImpl {
         this.identityFactory = identityFactory;
         this.messageSinkManager = messageSinkManager;
         this.queryFactory = queryFactory;
+        this.commandController = commandController;
         this.eventBus = eventBus;
         this.messageEncoderFactory = messageEncoderFactory;
         this.userSettings = userSettings;
@@ -84,14 +88,16 @@ public class ServerFactoryImpl {
 
     public Server getServer(
             final ConfigProviderMigrator configMigrator,
-            final CommandParser commandParser,
             final ScheduledExecutorService executorService,
             final URI uri,
             final Profile profile) {
-        return new Server(configMigrator, commandParser, parserFactory,
+        final Server server = new Server(configMigrator, parserFactory,
                 tabCompleterFactory, identityFactory, messageSinkManager,
                 queryFactory.get(), eventBus, messageEncoderFactory, userSettings,
                 groupChatManagerFactory, executorService, uri, profile, backBufferFactory,
                 userManager);
+        server.setCommandParser(new ServerCommandParser(server.getConfigManager(),
+                commandController.get(), eventBus, server));
+        return server;
     }
 }

--- a/src/com/dmdirc/ServerManager.java
+++ b/src/com/dmdirc/ServerManager.java
@@ -110,8 +110,6 @@ public class ServerManager implements ConnectionManager {
 
         final Server server = serverFactoryImpl.getServer(
                 configProvider,
-                new ServerCommandParser(configProvider.getConfigProvider(), commandController.get(),
-                        eventBus),
                 Executors.newScheduledThreadPool(1,
                         new ThreadFactoryBuilder().setNameFormat("server-timer-%d").build()),
                 uri,

--- a/src/com/dmdirc/commandparser/parsers/ChannelCommandParser.java
+++ b/src/com/dmdirc/commandparser/parsers/ChannelCommandParser.java
@@ -43,7 +43,7 @@ public class ChannelCommandParser extends ChatCommandParser {
     /** A version number for this class. */
     private static final long serialVersionUID = 1;
     /** The group chat instance that this parser is attached to. */
-    private GroupChat groupChat;
+    private final GroupChat groupChat;
 
     /**
      * Creates a new instance of ChannelCommandParser.
@@ -52,20 +52,14 @@ public class ChannelCommandParser extends ChatCommandParser {
      * @param commandController The controller to load commands from.
      * @param eventBus          Event bus to post events on
      */
-    public ChannelCommandParser(final WindowModel owner,
+    public ChannelCommandParser(
+            final WindowModel owner,
             final CommandController commandController,
-            final DMDircMBassador eventBus) {
-        super(owner, commandController, eventBus);
-    }
+            final DMDircMBassador eventBus,
+            final GroupChat groupChat) {
+        super(owner, commandController, eventBus, groupChat);
 
-    @Override
-    public void setOwner(final WindowModel owner) {
-        if (groupChat == null) {
-            // TODO: Can't assume that framecontainers may be group chats.
-            groupChat = (GroupChat) owner;
-        }
-
-        super.setOwner(owner);
+        this.groupChat = groupChat;
     }
 
     @Override

--- a/src/com/dmdirc/commandparser/parsers/ChatCommandParser.java
+++ b/src/com/dmdirc/commandparser/parsers/ChatCommandParser.java
@@ -45,7 +45,7 @@ public class ChatCommandParser extends ServerCommandParser {
     /** A version number for this class. */
     private static final long serialVersionUID = 1;
     /** The container that owns this parser. */
-    private Chat owner;
+    private final Chat owner;
 
     /**
      * Creates a new chat command parser that belongs to a child of the specified server.
@@ -54,17 +54,13 @@ public class ChatCommandParser extends ServerCommandParser {
      * @param commandController The controller to load commands from.
      * @param eventBus          Event but to post events on
      */
-    public ChatCommandParser(final WindowModel owner, final CommandController commandController,
-            final DMDircMBassador eventBus) {
-        super(owner.getConfigManager(), commandController, eventBus);
-        super.setOwner(owner);
-    }
-
-    @Override
-    public void setOwner(final WindowModel owner) {
-        if (this.owner == null && owner instanceof Chat) {
-            this.owner = (Chat) owner;
-        }
+    public ChatCommandParser(
+            final WindowModel owner,
+            final CommandController commandController,
+            final DMDircMBassador eventBus,
+            final Chat chat) {
+        super(owner.getConfigManager(), commandController, eventBus, chat.getConnection().get());
+        this.owner = chat;
     }
 
     @Override

--- a/src/com/dmdirc/commandparser/parsers/CommandParser.java
+++ b/src/com/dmdirc/commandparser/parsers/CommandParser.java
@@ -87,15 +87,6 @@ public abstract class CommandParser implements Serializable {
         loadCommands();
     }
 
-    /**
-     * Sets the owner of this command parser.
-     *
-     * @param owner The container which owns this parser
-     *
-     * @since 0.6.4
-     */
-    public abstract void setOwner(final WindowModel owner);
-
     /** Loads the relevant commands into the parser. */
     protected abstract void loadCommands();
 

--- a/src/com/dmdirc/commandparser/parsers/GlobalCommandParser.java
+++ b/src/com/dmdirc/commandparser/parsers/GlobalCommandParser.java
@@ -66,11 +66,6 @@ public class GlobalCommandParser extends CommandParser {
         this.eventBus = eventBus;
     }
 
-    @Override
-    public void setOwner(final WindowModel owner) {
-        // Don't care
-    }
-
     /** Loads the relevant commands into the parser. */
     @Override
     protected void loadCommands() {

--- a/src/com/dmdirc/commandparser/parsers/QueryCommandParser.java
+++ b/src/com/dmdirc/commandparser/parsers/QueryCommandParser.java
@@ -46,7 +46,7 @@ public class QueryCommandParser extends ChatCommandParser {
     /**
      * The query instance that this parser is attached to.
      */
-    private Query query;
+    private final Query query;
 
     /**
      * Creates a new instance of QueryCommandParser.
@@ -56,17 +56,9 @@ public class QueryCommandParser extends ChatCommandParser {
      * @param eventBus          Event bus to post events on
      */
     public QueryCommandParser(final WindowModel owner, final CommandController commandController,
-            final DMDircMBassador eventBus) {
-        super(owner, commandController, eventBus);
-    }
-
-    @Override
-    public void setOwner(final WindowModel owner) {
-        if (query == null) {
-            query = (Query) owner;
-        }
-
-        super.setOwner(query);
+            final DMDircMBassador eventBus, final Query query) {
+        super(owner, commandController, eventBus, query);
+        this.query = query;
     }
 
     /** Loads the relevant commands into the parser. */

--- a/src/com/dmdirc/commandparser/parsers/ServerCommandParser.java
+++ b/src/com/dmdirc/commandparser/parsers/ServerCommandParser.java
@@ -47,6 +47,11 @@ public class ServerCommandParser extends GlobalCommandParser {
     private static final long serialVersionUID = 1;
 
     /**
+     * The server instance that this parser is attached to.
+     */
+    private final Connection server;
+
+    /**
      * Creates a new command parser for server commands.
      *
      * @param configManager     Config manager to read settings from
@@ -56,21 +61,10 @@ public class ServerCommandParser extends GlobalCommandParser {
     public ServerCommandParser(
             final AggregateConfigProvider configManager,
             final CommandController commandController,
-            final DMDircMBassador eventBus) {
+            final DMDircMBassador eventBus,
+            final Connection connection) {
         super(configManager, commandController, eventBus);
-    }
-    /**
-     * The server instance that this parser is attached to.
-     */
-    private Connection server;
-
-    @Override
-    public void setOwner(final WindowModel owner) {
-        if (server == null && owner instanceof Connection) {
-            server = (Connection) owner;
-        }
-
-        super.setOwner(owner);
+        this.server = connection;
     }
 
     /** Loads the relevant commands into the parser. */

--- a/test/com/dmdirc/ServerManagerTest.java
+++ b/test/com/dmdirc/ServerManagerTest.java
@@ -22,7 +22,6 @@
 
 package com.dmdirc;
 
-import com.dmdirc.commandparser.parsers.CommandParser;
 import com.dmdirc.config.profiles.Profile;
 import com.dmdirc.config.profiles.ProfileManager;
 import com.dmdirc.interfaces.CommandController;
@@ -92,7 +91,7 @@ public class ServerManagerTest {
                 anyString())).thenReturn(configProviderMigrator);
         when(configProviderMigrator.getConfigProvider()).thenReturn(configProvider);
 
-        when(serverFactoryImpl.getServer(eq(configProviderMigrator), any(CommandParser.class),
+        when(serverFactoryImpl.getServer(eq(configProviderMigrator),
                 any(ScheduledExecutorService.class), uriCaptor.capture(), eq(profile)))
                 .thenReturn(server);
     }

--- a/test/com/dmdirc/harness/TestCommandParser.java
+++ b/test/com/dmdirc/harness/TestCommandParser.java
@@ -83,9 +83,4 @@ public class TestCommandParser extends CommandParser {
         invalidCommand = args.getCommandName();
     }
 
-    @Override
-    public void setOwner(final WindowModel owner) {
-        // Don't care
-    }
-
 }

--- a/test/com/dmdirc/harness/TestWritableFrameContainer.java
+++ b/test/com/dmdirc/harness/TestWritableFrameContainer.java
@@ -48,12 +48,12 @@ public class TestWritableFrameContainer extends FrameContainer {
             final DMDircMBassador eventBus,
             final BackBufferFactory backBufferFactory) {
         super(null, "raw", "Raw", "(Raw)", cm, backBufferFactory,
-                new GlobalCommandParser(cm, commandManager, eventBus),
                 new TabCompleter(mock(CommandController.class), cm),
                 messageSinkManager,
                 eventBus,
                 Collections.<String>emptySet());
 
+        setCommandParser(new GlobalCommandParser(cm, commandManager, eventBus));
         this.lineLength = lineLength;
     }
 


### PR DESCRIPTION
Instead of passing them in to the FrameContainer ctor, create
them afterwards.

This means the reference in FrameContainer can't be final but
removes the horrible setOwner() kludge that was previously in
CommandParser, and cuts down the deps needed to pass in to the
FrameContainer ctor.