### PR TITLE
Make a couple more events use new formatter.

### DIFF
--- a/res/com/dmdirc/ui/messages/format.yml
+++ b/res/com/dmdirc/ui/messages/format.yml
@@ -35,6 +35,15 @@ ServerAwayEvent:
 ServerBackEvent:
   format: "You are no longer marked as away."
   colour: 14
+ServerAuthNoticeEvent:
+  format: -AUTH- {{notice}}
+  colour: 5
+ServerInviteReceivedEvent:
+  format: * You have been invited to {{channel}} by {{user.nickname}}.
+  colour: 2
+ServerErrorEvent:
+  format: ERROR: {{reason}}
+  colour: 4
 
 ################## Server messaging events #########################################################
 
@@ -168,7 +177,6 @@ CommandOutputEvent:
 #  userModeChanged=3* %1$s sets user mode: %4$s.
 #  userNoModes=3* No user modes.
 #  userModeDiscovered=3* User modes are: %4$s.
-#  inviteReceived=2* You have been invited to %4$s by %1$s.
 #  walluser=5!%1$s! %4$s
 #  wallop=5$%1$s$ %4$s
 #  walldesync=5/%1$s/ %4$s
@@ -178,13 +186,11 @@ CommandOutputEvent:
 #  serverConnecting=Connecting to %1$s:%2$s...
 #  serverDisconnectInProgress=A disconnection attempt is in progress, please wait...
 #  serverConnectInProgress=A connection attempt is in progress, please wait...
-#  authNotice=5-AUTH- %1$s
 #  rawCommand=10>>> %1$s
 #  unknownCommand=14Unknown command %1$s.
 #  commandOutput=%1$s
 #  actionTooLong=Warning: action too long to be sent
 #  tabCompletion=14Multiple possibilities: %1$s
-#  serverError=4ERROR: %1$s
 #  serverUnknownProtocol=4Unknown protocol '%1$s'. Unable to connect.
 #  selfNickChange=3* You are now known as %2$s.
 #  unknownNotice=5-[%1$s:%2$s]- %3$s

--- a/src/com/dmdirc/ChannelEventHandler.java
+++ b/src/com/dmdirc/ChannelEventHandler.java
@@ -362,11 +362,8 @@ public class ChannelEventHandler extends EventHandler {
             return;
         }
 
-        final ChannelListModesRetrievedEvent coreEvent = new ChannelListModesRetrievedEvent(
-                event.getDate().getTime(), owner, event.getMode());
-        final String format = EventUtils.postDisplayable(eventBus, coreEvent,
-                "channelListModeRetrieved");
-        owner.doNotification(event.getDate(), format, event.getMode());
+        eventBus.publishAsync(new ChannelListModesRetrievedEvent(
+                event.getDate().getTime(), owner, event.getMode()));
     }
 
     private boolean checkChannel(final ChannelInfo channelInfo) {

--- a/src/com/dmdirc/ServerEventHandler.java
+++ b/src/com/dmdirc/ServerEventHandler.java
@@ -361,9 +361,7 @@ public class ServerEventHandler extends EventHandler {
     public void onNoticeAuth(final AuthNoticeEvent event) {
         checkParser(event.getParser());
 
-        final ServerAuthNoticeEvent coreEvent = new ServerAuthNoticeEvent(owner, event.getMessage());
-        final String format = EventUtils.postDisplayable(eventBus, coreEvent, "authNotice");
-        owner.doNotification(format, event.getDate());
+        eventBus.publishAsync(new ServerAuthNoticeEvent(owner, event.getMessage()));
     }
 
     @Handler
@@ -439,10 +437,8 @@ public class ServerEventHandler extends EventHandler {
         final Invite invite = new Invite(owner.getInviteManager(), event.getChannel(),
                 owner.getUser(event.getUserHost()));
         owner.getInviteManager().addInvite(invite);
-        final ServerInviteReceivedEvent coreEvent = new ServerInviteReceivedEvent(owner,
-                owner.getUser(event.getUserHost()), event.getChannel(), invite);
-        final String format = EventUtils.postDisplayable(eventBus, coreEvent, "inviteReceived");
-        owner.doNotification(format, owner.getUser(event.getUserHost()), event.getChannel());
+        eventBus.publishAsync(new ServerInviteReceivedEvent(owner,
+                owner.getUser(event.getUserHost()), event.getChannel(), invite));
     }
 
     @Handler
@@ -493,9 +489,7 @@ public class ServerEventHandler extends EventHandler {
     public void onServerError(final com.dmdirc.parser.events.ServerErrorEvent event) {
         checkParser(event.getParser());
 
-        final ServerErrorEvent coreEvent = new ServerErrorEvent(owner, event.getMessage());
-        final String format = EventUtils.postDisplayable(eventBus, coreEvent, "serverError");
-        owner.doNotification(format, event.getMessage());
+        eventBus.publishAsync(new ServerErrorEvent(owner, event.getMessage()));
     }
 
     @Override

--- a/src/com/dmdirc/events/ChannelListModesRetrievedEvent.java
+++ b/src/com/dmdirc/events/ChannelListModesRetrievedEvent.java
@@ -27,7 +27,7 @@ import com.dmdirc.interfaces.GroupChat;
 /**
  * Fired when channel list modes are retrieved.
  */
-public class ChannelListModesRetrievedEvent extends ChannelDisplayableEvent {
+public class ChannelListModesRetrievedEvent extends ChannelEvent {
 
     private final char mode;
 


### PR DESCRIPTION
Stop ChannelListModesRetrieved being displayable - not sure
why it ever was, we don't have a formatter for it.