### PR TITLE
Fix NPE on event bus errors.

### DIFF
--- a/src/com/dmdirc/DMDircMBassador.java
+++ b/src/com/dmdirc/DMDircMBassador.java
@@ -68,7 +68,7 @@ public class DMDircMBassador extends MBassador<DMDircEvent> {
             }
 
             synchronized (errorHandlerLock) {
-                final Throwable error = e.getCause().getCause();
+                final Throwable error = e.getCause();
                 publish(new AppErrorEvent(ErrorLevel.HIGH, error.getCause(), error.getMessage(),
                         ""));
             }


### PR DESCRIPTION
This keeps happening, and I don't know why we try to unwrap twice.
Probably only makes sense for certain exception types...