### PR TITLE
Fix some query nonsense.

### DIFF
--- a/src/com/dmdirc/Query.java
+++ b/src/com/dmdirc/Query.java
@@ -162,9 +162,6 @@ public class Query extends FrameContainer implements PrivateChat {
         if (!checkQuery(event.getHost())) {
             return;
         }
-        if (checkQuery(event.getHost())) {
-
-        }
         getEventBus().publishAsync(
                 new QueryMessageEvent(this, connection.getUser(event.getHost()), event.getMessage()));
     }
@@ -291,7 +288,7 @@ public class Query extends FrameContainer implements PrivateChat {
     }
 
     private boolean checkQuery(final String host) {
-        return user.getHostname().orElse("").equals(host);
+        return connection.getUser(host).getNickname().equals(user.getNickname());
     }
 
 }


### PR DESCRIPTION
For some reason we're checking hostname (e.g. dmdirc.com)
against full hosts (e.g. chris!ident@dmdirc.com) and expecting
them to match.

Queries now check on nicknames.