### PR TITLE
Relax META-INF exclusions for jars.

### DIFF
--- a/gradle/jar.gradle
+++ b/gradle/jar.gradle
@@ -56,7 +56,8 @@ jar {
     }
 
     from { configurations.bundle.collect { it.isDirectory() ? it : zipTree(it) } } {
-        exclude 'META-INF/**'
+        exclude 'META-INF/*'
+        exclude 'META-INF/maven/**'
     }
 
     manifest {


### PR DESCRIPTION
This allows service entries to be included.