### PR TITLE
Add a JUnit rule for using JimFS.

### DIFF
--- a/test/com/dmdirc/commandparser/aliases/DefaultAliasInstallerTest.java
+++ b/test/com/dmdirc/commandparser/aliases/DefaultAliasInstallerTest.java
@@ -22,16 +22,14 @@
 
 package com.dmdirc.commandparser.aliases;
 
-import com.google.common.jimfs.Configuration;
-import com.google.common.jimfs.Jimfs;
+import com.dmdirc.tests.JimFsRule;
 
 import java.io.IOException;
-import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -39,26 +37,20 @@ import org.mockito.runners.MockitoJUnitRunner;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings("resource")
 @RunWith(MockitoJUnitRunner.class)
 public class DefaultAliasInstallerTest {
 
-    private FileSystem fs;
+    @Rule public final JimFsRule jimFsRule = new JimFsRule();
+
     private Path path;
 
     private DefaultAliasInstaller installer;
 
     @Before
     public void setup() {
-        fs = Jimfs.newFileSystem(Configuration.unix().toBuilder()
-                .setAttributeViews("posix").build());
-        path = fs.getPath("aliases.yml");
-
+        path = jimFsRule.getFileSystem().getPath("aliases.yml");
         installer = new DefaultAliasInstaller(path);
-    }
-
-    @After
-    public void tearDown() throws IOException {
-        fs.close();
     }
 
     @Test

--- a/test/com/dmdirc/commandparser/auto/YamlAutoCommandStoreTest.java
+++ b/test/com/dmdirc/commandparser/auto/YamlAutoCommandStoreTest.java
@@ -22,26 +22,28 @@
 
 package com.dmdirc.commandparser.auto;
 
+import com.dmdirc.tests.JimFsRule;
+
 import com.google.common.collect.Sets;
-import com.google.common.jimfs.Configuration;
-import com.google.common.jimfs.Jimfs;
 
 import java.io.IOException;
-import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.util.Optional;
 import java.util.Set;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings("resource")
 public class YamlAutoCommandStoreTest {
 
-    private FileSystem fs;
+    @Rule public final JimFsRule jimFsRule = new JimFsRule();
+
     private YamlAutoCommandStore ycs;
     private AutoCommand command;
     private AutoCommand command1;
@@ -51,9 +53,8 @@ public class YamlAutoCommandStoreTest {
 
     @Before
     public void setup() throws IOException {
-        fs = Jimfs.newFileSystem(Configuration.unix());
         Files.copy(getClass().getResource("readtest.yml").openStream(),
-                fs.getPath("readtest.yml"));
+                jimFsRule.getFileSystem().getPath("readtest.yml"));
         command = AutoCommand.create(Optional.ofNullable("server"),
                 Optional.ofNullable("network"),
                 Optional.ofNullable("profile"),
@@ -76,7 +77,7 @@ public class YamlAutoCommandStoreTest {
 
     @Test
     public void testReadAutoCommands() {
-        ycs = new YamlAutoCommandStore(fs.getPath("readtest.yml"));
+        ycs = new YamlAutoCommandStore(jimFsRule.getFileSystem().getPath("readtest.yml"));
         final Set<AutoCommand> commands = ycs.readAutoCommands();
         assertTrue("Command 1 not present", commands.contains(command1));
         assertTrue("Command 2 not present", commands.contains(command2));
@@ -86,13 +87,13 @@ public class YamlAutoCommandStoreTest {
 
     @Test
     public void testWriteAutoCommands() throws IOException {
-        ycs = new YamlAutoCommandStore(fs.getPath("store.yml"));
+        ycs = new YamlAutoCommandStore(jimFsRule.getFileSystem().getPath("store.yml"));
         assertEquals(0, ycs.readAutoCommands().size());
-        assertFalse(Files.exists(fs.getPath("store.yml")));
+        assertFalse(Files.exists(jimFsRule.getFileSystem().getPath("store.yml")));
         ycs.writeAutoCommands(Sets.newHashSet(command));
         final Set<AutoCommand> commands = ycs.readAutoCommands();
         assertTrue("Command not present", commands.contains(command));
-        assertTrue(Files.exists(fs.getPath("store.yml")));
+        assertTrue(Files.exists(jimFsRule.getFileSystem().getPath("store.yml")));
     }
 
 }

--- a/test/com/dmdirc/config/IdentityManagerTest.java
+++ b/test/com/dmdirc/config/IdentityManagerTest.java
@@ -24,18 +24,16 @@ package com.dmdirc.config;
 
 import com.dmdirc.DMDircMBassador;
 import com.dmdirc.interfaces.config.ConfigProvider;
+import com.dmdirc.tests.JimFsRule;
 import com.dmdirc.util.ClientInfo;
 
-import com.google.common.jimfs.Configuration;
-import com.google.common.jimfs.Jimfs;
-
 import java.io.IOException;
-import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -47,6 +45,8 @@ import static org.junit.Assert.assertNotNull;
 @RunWith(MockitoJUnitRunner.class)
 public class IdentityManagerTest {
 
+    @Rule public final JimFsRule jimFsRule = new JimFsRule();
+
     @Mock private DMDircMBassador eventBus;
     @Mock private ClientInfo clientInfo;
 
@@ -56,8 +56,7 @@ public class IdentityManagerTest {
     @Before
     @SuppressWarnings("resource")
     public void setUp() throws Exception {
-        final FileSystem fs = Jimfs.newFileSystem(Configuration.unix());
-        baseDirectory = fs.getPath("config");
+        baseDirectory = jimFsRule.getFileSystem().getPath("config");
         identitiesDirectory = baseDirectory.resolve("identities");
     }
 

--- a/test/com/dmdirc/tests/JimFsRule.java
+++ b/test/com/dmdirc/tests/JimFsRule.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2006-2015 DMDirc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.dmdirc.tests;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+
+import java.nio.file.FileSystem;
+
+import javax.annotation.WillCloseWhenClosed;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * JUnit rule to create a JimFS file system and automatically close it on completion.
+ */
+public class JimFsRule implements TestRule {
+
+    private FileSystem fileSystem;
+
+    @Override
+    public Statement apply(final Statement base, final Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                fileSystem = Jimfs.newFileSystem(Configuration.unix());
+                try {
+                    base.evaluate();
+                } finally {
+                    fileSystem.close();
+                }
+            }
+        };
+    }
+
+    @WillCloseWhenClosed
+    public FileSystem getFileSystem() {
+        return fileSystem;
+    }
+
+}

--- a/test/com/dmdirc/util/URLBuilderTest.java
+++ b/test/com/dmdirc/util/URLBuilderTest.java
@@ -26,19 +26,17 @@ import com.dmdirc.DMDircMBassador;
 import com.dmdirc.plugins.PluginInfo;
 import com.dmdirc.plugins.PluginManager;
 import com.dmdirc.plugins.PluginMetaData;
+import com.dmdirc.tests.JimFsRule;
 import com.dmdirc.ui.themes.ThemeManager;
-
-import com.google.common.jimfs.Configuration;
-import com.google.common.jimfs.Jimfs;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.file.FileSystem;
 
 import javax.inject.Provider;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;
@@ -50,6 +48,8 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class URLBuilderTest {
 
+    @Rule public final JimFsRule jimFsRule = new JimFsRule();
+
     @Mock private Provider<PluginManager> pluginManagerProvider;
     @Mock private Provider<ThemeManager> themeManagerProvider;
     @Mock private PluginManager pluginManager;
@@ -59,14 +59,15 @@ public class URLBuilderTest {
     @Mock private DMDircMBassador eventBus;
 
     @Before
+    @SuppressWarnings("resource")
     public void setup() throws MalformedURLException {
-        final FileSystem fs = Jimfs.newFileSystem(Configuration.unix());
         when(pluginManagerProvider.get()).thenReturn(pluginManager);
         when(themeManagerProvider.get()).thenReturn(themeManager);
         when(pluginManager.getPluginInfoByName(Matchers.anyString())).thenReturn(pluginInfo);
         when(themeManager.getDirectory()).thenReturn("/themes/");
         when(pluginInfo.getMetaData()).thenReturn(pluginMetaData);
-        when(pluginMetaData.getPluginPath()).thenReturn(fs.getPath("file://testPlugin"));
+        when(pluginMetaData.getPluginPath()).thenReturn(
+                jimFsRule.getFileSystem().getPath("file://testPlugin"));
     }
 
     @Test
@@ -94,7 +95,8 @@ public class URLBuilderTest {
     public void testGetUrlForJarFile() throws MalformedURLException {
         final URLBuilder urlBuilder
                 = new URLBuilder(pluginManagerProvider, themeManagerProvider);
-        Assert.assertEquals(new URL("jar:file:/jarFile!/test"), urlBuilder.getUrlForJarFile("jarFile", "test"));
+        Assert.assertEquals(new URL("jar:file:/jarFile!/test"),
+                urlBuilder.getUrlForJarFile("jarFile", "test"));
     }
 
     @Test
@@ -124,14 +126,16 @@ public class URLBuilderTest {
     public void testGetUrlForThemeResource() throws MalformedURLException {
         final URLBuilder urlBuilder
                 = new URLBuilder(pluginManagerProvider, themeManagerProvider);
-        Assert.assertEquals(new URL("jar:file:/themes/testTheme.zip!/testFile"), urlBuilder.getUrlForThemeResource("testTheme", "testFile"));
+        Assert.assertEquals(new URL("jar:file:/themes/testTheme.zip!/testFile"),
+                urlBuilder.getUrlForThemeResource("testTheme", "testFile"));
     }
 
     @Test
     public void testGetUrlForPluginResource() throws MalformedURLException {
         final URLBuilder urlBuilder
                 = new URLBuilder(pluginManagerProvider, themeManagerProvider);
-        Assert.assertEquals(new URL("jar:file:/testPlugin!/testFile"), urlBuilder.getUrlForPluginResource("testPlugin", "testFile"));
+        Assert.assertEquals(new URL("jar:file:/testPlugin!/testFile"),
+                urlBuilder.getUrlForPluginResource("testPlugin", "testFile"));
     }
 
     @Test
@@ -147,7 +151,8 @@ public class URLBuilderTest {
     public void testGetUrlJar() throws MalformedURLException {
         final URLBuilder urlBuilder
                 = new URLBuilder(pluginManagerProvider, themeManagerProvider);
-        Assert.assertEquals(new URL("jar:file:/jarFile!/testFile"), urlBuilder.getUrl("jar://jarFile:testFile"));
+        Assert.assertEquals(new URL("jar:file:/jarFile!/testFile"),
+                urlBuilder.getUrl("jar://jarFile:testFile"));
     }
 
     @Test
@@ -161,7 +166,8 @@ public class URLBuilderTest {
     public void testGetUrlZip() throws MalformedURLException {
         final URLBuilder urlBuilder
                 = new URLBuilder(pluginManagerProvider, themeManagerProvider);
-        Assert.assertEquals(new URL("jar:file:/zipFile!/testFile"), urlBuilder.getUrl("zip://zipFile:testFile"));
+        Assert.assertEquals(new URL("jar:file:/zipFile!/testFile"),
+                urlBuilder.getUrl("zip://zipFile:testFile"));
     }
 
     @Test
@@ -175,7 +181,8 @@ public class URLBuilderTest {
     public void testGetUrlPlugin() throws MalformedURLException {
         final URLBuilder urlBuilder
                 = new URLBuilder(pluginManagerProvider, themeManagerProvider);
-        Assert.assertEquals(new URL("jar:file:/testPlugin!/testFile"), urlBuilder.getUrl("plugin://pluginFile:testFile"));
+        Assert.assertEquals(new URL("jar:file:/testPlugin!/testFile"),
+                urlBuilder.getUrl("plugin://pluginFile:testFile"));
     }
 
     @Test
@@ -189,7 +196,8 @@ public class URLBuilderTest {
     public void testGetUrlTheme() throws MalformedURLException {
         final URLBuilder urlBuilder
                 = new URLBuilder(pluginManagerProvider, themeManagerProvider);
-        Assert.assertEquals(new URL("jar:file:/themes/themeFile.zip!/testFile"), urlBuilder.getUrl("theme://themeFile:testFile"));
+        Assert.assertEquals(new URL("jar:file:/themes/themeFile.zip!/testFile"),
+                urlBuilder.getUrl("theme://themeFile:testFile"));
     }
 
     @Test


### PR DESCRIPTION
This means each test doesn't have to set it up and tear it down
manually (although only one actually did bother to tear it down :)).