### PR TITLE
Add getPath utility method to JimFsRule.

### DIFF
--- a/test/com/dmdirc/commandparser/aliases/ActionAliasMigratorTest.java
+++ b/test/com/dmdirc/commandparser/aliases/ActionAliasMigratorTest.java
@@ -38,7 +38,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.verify;
 
-@SuppressWarnings("resource")
 @RunWith(MockitoJUnitRunner.class)
 public class ActionAliasMigratorTest {
 
@@ -53,23 +52,20 @@ public class ActionAliasMigratorTest {
 
     @Before
     public void setup() throws IOException {
-        Files.createDirectories(jimFsRule.getFileSystem().getPath("test1/aliases"));
-        Files.createDirectories(jimFsRule.getFileSystem().getPath("test2/other-stuff/aliases"));
-        Files.createDirectories(jimFsRule.getFileSystem().getPath("test3/aliases"));
+        Files.createDirectories(jimFsRule.getPath("test1/aliases"));
+        Files.createDirectories(jimFsRule.getPath("test2/other-stuff/aliases"));
+        Files.createDirectories(jimFsRule.getPath("test3/aliases"));
 
         Files.copy(getClass().getResource("op-greater-0").openStream(),
-                jimFsRule.getFileSystem().getPath("test1/aliases/op"));
+                jimFsRule.getPath("test1/aliases/op"));
         Files.copy(getClass().getResource("unset-equals-2").openStream(),
-                jimFsRule.getFileSystem().getPath("test1/aliases/unset"));
+                jimFsRule.getPath("test1/aliases/unset"));
         Files.copy(getClass().getResource("no-trigger").openStream(),
-                jimFsRule.getFileSystem().getPath("test3/aliases/bad"));
+                jimFsRule.getPath("test3/aliases/bad"));
 
-        migrator1 = new ActionAliasMigrator(jimFsRule.getFileSystem().getPath("test1"),
-                aliasFactory, aliasManager);
-        migrator2 = new ActionAliasMigrator(jimFsRule.getFileSystem().getPath("test2"),
-                aliasFactory, aliasManager);
-        migrator3 = new ActionAliasMigrator(jimFsRule.getFileSystem().getPath("test3"),
-                aliasFactory, aliasManager);
+        migrator1 = new ActionAliasMigrator(jimFsRule.getPath("test1"), aliasFactory, aliasManager);
+        migrator2 = new ActionAliasMigrator(jimFsRule.getPath("test2"), aliasFactory, aliasManager);
+        migrator3 = new ActionAliasMigrator(jimFsRule.getPath("test3"), aliasFactory, aliasManager);
     }
 
     @Test
@@ -81,16 +77,16 @@ public class ActionAliasMigratorTest {
     @Test
     public void testDeletesFilesAfterMigration() {
         migrator1.migrate();
-        assertFalse(Files.exists(jimFsRule.getFileSystem().getPath("test1/aliases/unset")));
-        assertFalse(Files.exists(jimFsRule.getFileSystem().getPath("test1/aliases/op")));
-        assertFalse(Files.exists(jimFsRule.getFileSystem().getPath("test1/aliases")));
-        assertTrue(Files.exists(jimFsRule.getFileSystem().getPath("test1")));
+        assertFalse(Files.exists(jimFsRule.getPath("test1/aliases/unset")));
+        assertFalse(Files.exists(jimFsRule.getPath("test1/aliases/op")));
+        assertFalse(Files.exists(jimFsRule.getPath("test1/aliases")));
+        assertTrue(Files.exists(jimFsRule.getPath("test1")));
     }
 
     @Test
     public void testLeavesOtherFilesDuringMigration() {
         migrator2.migrate();
-        assertTrue(Files.exists(jimFsRule.getFileSystem().getPath("test2/other-stuff/aliases")));
+        assertTrue(Files.exists(jimFsRule.getPath("test2/other-stuff/aliases")));
     }
 
     @Test
@@ -103,7 +99,7 @@ public class ActionAliasMigratorTest {
     @Test
     public void testBadActionsLeftOnDisk() {
         migrator3.migrate();
-        assertTrue(Files.exists(jimFsRule.getFileSystem().getPath("test3/aliases/bad")));
+        assertTrue(Files.exists(jimFsRule.getPath("test3/aliases/bad")));
     }
 
 }

--- a/test/com/dmdirc/commandparser/aliases/DefaultAliasInstallerTest.java
+++ b/test/com/dmdirc/commandparser/aliases/DefaultAliasInstallerTest.java
@@ -37,7 +37,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@SuppressWarnings("resource")
 @RunWith(MockitoJUnitRunner.class)
 public class DefaultAliasInstallerTest {
 
@@ -49,7 +48,7 @@ public class DefaultAliasInstallerTest {
 
     @Before
     public void setup() {
-        path = jimFsRule.getFileSystem().getPath("aliases.yml");
+        path = jimFsRule.getPath("aliases.yml");
         installer = new DefaultAliasInstaller(path);
     }
 

--- a/test/com/dmdirc/commandparser/auto/YamlAutoCommandStoreTest.java
+++ b/test/com/dmdirc/commandparser/auto/YamlAutoCommandStoreTest.java
@@ -39,7 +39,6 @@ import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@SuppressWarnings("resource")
 public class YamlAutoCommandStoreTest {
 
     @Rule public final JimFsRule jimFsRule = new JimFsRule();
@@ -54,7 +53,7 @@ public class YamlAutoCommandStoreTest {
     @Before
     public void setup() throws IOException {
         Files.copy(getClass().getResource("readtest.yml").openStream(),
-                jimFsRule.getFileSystem().getPath("readtest.yml"));
+                jimFsRule.getPath("readtest.yml"));
         command = AutoCommand.create(Optional.ofNullable("server"),
                 Optional.ofNullable("network"),
                 Optional.ofNullable("profile"),
@@ -77,7 +76,7 @@ public class YamlAutoCommandStoreTest {
 
     @Test
     public void testReadAutoCommands() {
-        ycs = new YamlAutoCommandStore(jimFsRule.getFileSystem().getPath("readtest.yml"));
+        ycs = new YamlAutoCommandStore(jimFsRule.getPath("readtest.yml"));
         final Set<AutoCommand> commands = ycs.readAutoCommands();
         assertTrue("Command 1 not present", commands.contains(command1));
         assertTrue("Command 2 not present", commands.contains(command2));
@@ -87,13 +86,13 @@ public class YamlAutoCommandStoreTest {
 
     @Test
     public void testWriteAutoCommands() throws IOException {
-        ycs = new YamlAutoCommandStore(jimFsRule.getFileSystem().getPath("store.yml"));
+        ycs = new YamlAutoCommandStore(jimFsRule.getPath("store.yml"));
         assertEquals(0, ycs.readAutoCommands().size());
-        assertFalse(Files.exists(jimFsRule.getFileSystem().getPath("store.yml")));
+        assertFalse(Files.exists(jimFsRule.getPath("store.yml")));
         ycs.writeAutoCommands(Sets.newHashSet(command));
         final Set<AutoCommand> commands = ycs.readAutoCommands();
         assertTrue("Command not present", commands.contains(command));
-        assertTrue(Files.exists(jimFsRule.getFileSystem().getPath("store.yml")));
+        assertTrue(Files.exists(jimFsRule.getPath("store.yml")));
     }
 
 }

--- a/test/com/dmdirc/config/ConfigFileBackedConfigProviderTest.java
+++ b/test/com/dmdirc/config/ConfigFileBackedConfigProviderTest.java
@@ -50,7 +50,6 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-@SuppressWarnings("resource")
 @RunWith(MockitoJUnitRunner.class)
 public class ConfigFileBackedConfigProviderTest {
 
@@ -70,27 +69,26 @@ public class ConfigFileBackedConfigProviderTest {
     @Before
     public void setUp() throws Exception {
         for (String file: FILES) {
-            Files.copy(getClass().getResourceAsStream(file),
-                    jimFsRule.getFileSystem().getPath(file));
+            Files.copy(getClass().getResourceAsStream(file), jimFsRule.getPath(file));
         }
     }
 
     @Test(expected = InvalidIdentityFileException.class)
     public void testNoName() throws IOException, InvalidIdentityFileException {
         new ConfigFileBackedConfigProvider(identityManager,
-                jimFsRule.getFileSystem().getPath("no-name"), false);
+                jimFsRule.getPath("no-name"), false);
     }
 
     @Test(expected = InvalidIdentityFileException.class)
     public void testNoTarget() throws IOException, InvalidIdentityFileException {
         new ConfigFileBackedConfigProvider(identityManager,
-                jimFsRule.getFileSystem().getPath("no-target"), false);
+                jimFsRule.getPath("no-target"), false);
     }
 
     @Test(expected = InvalidIdentityFileException.class)
     public void testInvalidConfigFile() throws IOException, InvalidIdentityFileException {
         new ConfigFileBackedConfigProvider(identityManager,
-                jimFsRule.getFileSystem().getPath("invalid-config-file"), false);
+                jimFsRule.getPath("invalid-config-file"), false);
     }
 
     @Test
@@ -313,16 +311,14 @@ public class ConfigFileBackedConfigProviderTest {
 
     private void copyFileAndReload(final ConfigProvider provider)
             throws IOException, InvalidConfigFileException {
-        Files.copy(jimFsRule.getFileSystem().getPath("simple-ircd-extra"),
-                jimFsRule.getFileSystem().getPath("simple-ircd"),
+        Files.copy(jimFsRule.getPath("simple-ircd-extra"), jimFsRule.getPath("simple-ircd"),
                 StandardCopyOption.REPLACE_EXISTING);
         provider.reload();
     }
 
     private ConfigFileBackedConfigProvider getProvider(final String file)
             throws IOException, InvalidIdentityFileException {
-        return new ConfigFileBackedConfigProvider(identityManager,
-                jimFsRule.getFileSystem().getPath(file), false);
+        return new ConfigFileBackedConfigProvider(identityManager, jimFsRule.getPath(file), false);
     }
 
 }

--- a/test/com/dmdirc/config/IdentityManagerTest.java
+++ b/test/com/dmdirc/config/IdentityManagerTest.java
@@ -54,9 +54,8 @@ public class IdentityManagerTest {
     private Path identitiesDirectory;
 
     @Before
-    @SuppressWarnings("resource")
     public void setUp() throws Exception {
-        baseDirectory = jimFsRule.getFileSystem().getPath("config");
+        baseDirectory = jimFsRule.getPath("config");
         identitiesDirectory = baseDirectory.resolve("identities");
     }
 

--- a/test/com/dmdirc/logger/DiskLoggingErrorManagerTest.java
+++ b/test/com/dmdirc/logger/DiskLoggingErrorManagerTest.java
@@ -45,7 +45,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@SuppressWarnings("resource")
 @RunWith(MockitoJUnitRunner.class)
 public class DiskLoggingErrorManagerTest {
 
@@ -67,16 +66,16 @@ public class DiskLoggingErrorManagerTest {
         when(programError.getThrowableAsString()).thenReturn(Optional.of("test"));
         when(programError.getLevel()).thenReturn(ErrorLevel.MEDIUM);
         when(config.getBinder()).thenReturn(configBinder);
-        instance = new DiskLoggingErrorManager(jimFsRule.getFileSystem().getPath("/errors"),
+        instance = new DiskLoggingErrorManager(jimFsRule.getPath("/errors"),
                 eventBus);
     }
 
     @Test
     public void testInitialise() throws Exception {
-        assertFalse(Files.exists(jimFsRule.getFileSystem().getPath("/errors")));
+        assertFalse(Files.exists(jimFsRule.getPath("/errors")));
         instance.initialise(config);
         verify(configBinder).bind(instance, DiskLoggingErrorManager.class);
-        assertTrue(Files.exists(jimFsRule.getFileSystem().getPath("/errors")));
+        assertTrue(Files.exists(jimFsRule.getPath("/errors")));
         assertFalse(instance.isDirectoryError());
     }
 
@@ -90,9 +89,9 @@ public class DiskLoggingErrorManagerTest {
         instance.initialise(config);
         instance.handleLoggingSetting(true);
         final String logName = error.getTimestamp() + "-" + error.getError().getLevel() + ".log";;
-        assertFalse(Files.exists(jimFsRule.getFileSystem().getPath("/errors", logName)));
+        assertFalse(Files.exists(jimFsRule.getPath("/errors", logName)));
         instance.handleErrorEvent(error);
-        final Path errorPath = jimFsRule.getFileSystem().getPath("/errors", logName);
+        final Path errorPath = jimFsRule.getPath("/errors", logName);
         assertTrue(Files.exists(errorPath));
         assertTrue(Files.readAllLines(errorPath).contains("Level: Medium"));
     }
@@ -102,9 +101,9 @@ public class DiskLoggingErrorManagerTest {
         instance.initialise(config);
         instance.handleLoggingSetting(false);
         final String logName = error.getTimestamp() + "-" + error.getError().getLevel() + ".log";;
-        assertFalse(Files.exists(jimFsRule.getFileSystem().getPath("/errors", logName)));
+        assertFalse(Files.exists(jimFsRule.getPath("/errors", logName)));
         instance.handleErrorEvent(error);
-        assertFalse(Files.exists(jimFsRule.getFileSystem().getPath("/errors", logName)));
+        assertFalse(Files.exists(jimFsRule.getPath("/errors", logName)));
     }
 
     @Test

--- a/test/com/dmdirc/tests/JimFsRule.java
+++ b/test/com/dmdirc/tests/JimFsRule.java
@@ -26,8 +26,7 @@ import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 
 import java.nio.file.FileSystem;
-
-import javax.annotation.WillCloseWhenClosed;
+import java.nio.file.Path;
 
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
@@ -55,9 +54,24 @@ public class JimFsRule implements TestRule {
         };
     }
 
-    @WillCloseWhenClosed
+    /**
+     * Gets the file system for use in the test.
+     *
+     * @return The JimFS filesystem.
+     */
     public FileSystem getFileSystem() {
         return fileSystem;
+    }
+
+    /**
+     * Utility method to get a path from the file system.
+     *
+     * @param first The first component of the path
+     * @param more Any additional path components
+     * @return A corresponding {@link Path} object from the JimFS file system.
+     */
+    public Path getPath(final String first, final String ... more) {
+        return fileSystem.getPath(first, more);
     }
 
 }

--- a/test/com/dmdirc/util/URLBuilderTest.java
+++ b/test/com/dmdirc/util/URLBuilderTest.java
@@ -59,15 +59,13 @@ public class URLBuilderTest {
     @Mock private DMDircMBassador eventBus;
 
     @Before
-    @SuppressWarnings("resource")
     public void setup() throws MalformedURLException {
         when(pluginManagerProvider.get()).thenReturn(pluginManager);
         when(themeManagerProvider.get()).thenReturn(themeManager);
         when(pluginManager.getPluginInfoByName(Matchers.anyString())).thenReturn(pluginInfo);
         when(themeManager.getDirectory()).thenReturn("/themes/");
         when(pluginInfo.getMetaData()).thenReturn(pluginMetaData);
-        when(pluginMetaData.getPluginPath()).thenReturn(
-                jimFsRule.getFileSystem().getPath("file://testPlugin"));
+        when(pluginMetaData.getPluginPath()).thenReturn(jimFsRule.getPath("file://testPlugin"));
     }
 
     @Test


### PR DESCRIPTION
This saves getting the FS and suffering the barrage of warnings
related to auto-closeable resources.