### PR TITLE
Fix source of notice events.

### DIFF
--- a/src/com/dmdirc/ServerEventHandler.java
+++ b/src/com/dmdirc/ServerEventHandler.java
@@ -218,7 +218,7 @@ public class ServerEventHandler extends EventHandler {
 
     @Handler
     public void onPrivateNotice(final PrivateNoticeEvent event) {
-        eventBus.publishAsync(new ServerNoticeEvent(owner, owner.getLocalUser().get(),
+        eventBus.publishAsync(new ServerNoticeEvent(owner, owner.getUser(event.getHost()),
                 event.getMessage()));
     }
 


### PR DESCRIPTION
We were raising notices as all coming from the local user, not
the person that sent the notice. This is... unideal.