### PR TITLE
Add formatter support for before/after templates.

### DIFF
--- a/src/com/dmdirc/ui/messages/EventFormat.java
+++ b/src/com/dmdirc/ui/messages/EventFormat.java
@@ -34,15 +34,23 @@ import java.util.Optional;
 @AutoValue
 public abstract class EventFormat {
 
+    /** The template to use when rendering the event. */
     public abstract String getTemplate();
+    /** The template to use before starting to render the event. */
+    public abstract Optional<String> getBeforeTemplate();
+    /** The template to use after finishing rendering the event. */
+    public abstract Optional<String> getAfterTemplate();
 
     // TODO: This should probably be a generic set of properties.
     public abstract Optional<Colour> getDefaultForegroundColour();
 
     public static EventFormat create(
             final String template,
+            final Optional<String> beforeTemplate,
+            final Optional<String> afterTemplate,
             final Optional<Colour> defaultForegroundColour) {
-        return new AutoValue_EventFormat(template, defaultForegroundColour);
+        return new AutoValue_EventFormat(template, beforeTemplate, afterTemplate,
+                defaultForegroundColour);
     }
 
 }

--- a/src/com/dmdirc/ui/messages/EventFormatter.java
+++ b/src/com/dmdirc/ui/messages/EventFormatter.java
@@ -66,7 +66,7 @@ public class EventFormatter {
         }
 
         return format.map(f -> {
-            final StringBuilder builder = new StringBuilder(f.getTemplate());
+            final StringBuilder builder = getTemplate(f, event);
             int tagStart = builder.indexOf("{{");
             while (tagStart > -1) {
                 final int tagEnd = builder.indexOf("}}", tagStart);
@@ -78,6 +78,14 @@ public class EventFormatter {
 
             return builder.toString();
         });
+    }
+
+    private StringBuilder getTemplate(final EventFormat format, final DisplayableEvent event) {
+        final StringBuilder builder = new StringBuilder();
+        format.getBeforeTemplate().ifPresent(before -> builder.append(before).append('\n'));
+        builder.append(format.getTemplate());
+        format.getAfterTemplate().ifPresent(after -> builder.append('\n').append(after));
+        return builder;
     }
 
     private String getReplacement(final DisplayableEvent event, final String tag) {

--- a/src/com/dmdirc/ui/messages/YamlEventFormatProvider.java
+++ b/src/com/dmdirc/ui/messages/YamlEventFormatProvider.java
@@ -93,11 +93,17 @@ public class YamlEventFormatProvider implements EventFormatProvider {
     private EventFormat readFormat(final Object format) {
         final Map<Object, Object> info = asMap(format);
         final String template = info.get("format").toString();
+        final Optional<String> beforeTemplate = info.containsKey("before")
+                ? Optional.of(info.get("before").toString())
+                : Optional.empty();
+        final Optional<String> afterTemplate = info.containsKey("after")
+                ? Optional.of(info.get("after").toString())
+                : Optional.empty();
         final Optional<Colour> foregroundColour = info.containsKey("colour")
                 ? Optional.of(colourManager.getColourFromIrcCode(
                         Integer.parseInt(info.get("colour").toString())))
                 : Optional.empty();
-        return EventFormat.create(template, foregroundColour);
+        return EventFormat.create(template, beforeTemplate, afterTemplate, foregroundColour);
     }
 
     @Override

--- a/test/com/dmdirc/ui/messages/EventFormatterTest.java
+++ b/test/com/dmdirc/ui/messages/EventFormatterTest.java
@@ -56,11 +56,34 @@ public class EventFormatterTest {
 
         when(templateProvider.getFormat(ChannelMessageEvent.class))
                 .thenReturn(Optional.of(
-                        EventFormat.create("Template {{channel}} meep", Optional.empty())));
+                        EventFormat.create(
+                                "Template {{channel}} meep",
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty())));
         when(propertyManager.getProperty(messageEvent, ChannelMessageEvent.class, "channel"))
                 .thenReturn(Optional.of("MONKEY"));
 
         assertEquals("Template MONKEY meep", formatter.format(messageEvent).orElse(null));
+    }
+
+    @Test
+    public void testBeforeAndAfterFormat() {
+        messageEvent = new ChannelMessageEvent(channel, null, null);
+
+        when(templateProvider.getFormat(ChannelMessageEvent.class))
+                .thenReturn(Optional.of(
+                        EventFormat.create(
+                                "Template {{channel}} meep",
+                                Optional.of("Before!"),
+                                Optional.of("After!"),
+                                Optional.empty())));
+        when(propertyManager.getProperty(messageEvent, ChannelMessageEvent.class, "channel"))
+                .thenReturn(Optional.of("MONKEY"));
+
+        assertEquals(
+                "Before!\nTemplate MONKEY meep\nAfter!",
+                formatter.format(messageEvent).orElse(null));
     }
 
     @Test
@@ -69,7 +92,10 @@ public class EventFormatterTest {
 
         when(templateProvider.getFormat(ChannelMessageEvent.class))
                 .thenReturn(Optional.of(
-                        EventFormat.create("Template {{channel|lowercase}} meep",
+                        EventFormat.create(
+                                "Template {{channel|lowercase}} meep",
+                                Optional.empty(),
+                                Optional.empty(),
                                 Optional.empty())));
         when(propertyManager.getProperty(messageEvent, ChannelMessageEvent.class, "channel"))
                 .thenReturn(Optional.of("MONKEY"));
@@ -84,7 +110,11 @@ public class EventFormatterTest {
 
         when(templateProvider.getFormat(ChannelMessageEvent.class))
                 .thenReturn(Optional.of(
-                        EventFormat.create("Template {{message}} meep", Optional.empty())));
+                        EventFormat.create(
+                                "Template {{message}} meep",
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty())));
         when(propertyManager.getProperty(messageEvent, ChannelMessageEvent.class, "message"))
                 .thenReturn(Optional.of("{{channel}}"));
 


### PR DESCRIPTION
This allows formats that may be multi-line (whois results,
probably MOTD results at some point, etc...) to show a header
and footer around the actual content.