### PR TITLE
Add display property to suppress timestamps.

### DIFF
--- a/src/com/dmdirc/events/DisplayProperty.java
+++ b/src/com/dmdirc/events/DisplayProperty.java
@@ -36,6 +36,8 @@ public interface DisplayProperty<T> {
     DisplayProperty<Colour> BACKGROUND_COLOUR = new DisplayPropertyImpl<>();
     /** Whether to suppress display of the event. */
     DisplayProperty<Boolean> DO_NOT_DISPLAY = new DisplayPropertyImpl<>();
+    /** Whether to suppress timestamps for the event. */
+    DisplayProperty<Boolean> NO_TIMESTAMPS = new DisplayPropertyImpl<>();
 
     final class DisplayPropertyImpl<T> implements DisplayProperty<T> {}
 

--- a/src/com/dmdirc/events/DisplayPropertyMap.java
+++ b/src/com/dmdirc/events/DisplayPropertyMap.java
@@ -22,6 +22,7 @@
 
 package com.dmdirc.events;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -59,6 +60,15 @@ public class DisplayPropertyMap {
     }
 
     /**
+     * Adds all properties from the other map to this one.
+     *
+     * @param other The map to add properties from.
+     */
+    public void putAll(final DisplayPropertyMap other) {
+        properties.putAll(other.getProperties());
+    }
+
+    /**
      * Removes a value for the specified property.
      *
      * @param property The property to be removed
@@ -66,6 +76,15 @@ public class DisplayPropertyMap {
      */
     public <T> void remove(final DisplayProperty<T> property) {
         properties.remove(property);
+    }
+
+    /**
+     * Returns a readonly copy of this map's properties
+     *
+     * @return This map's properties.
+     */
+    Map<DisplayProperty<?>, Object> getProperties() {
+        return Collections.unmodifiableMap(properties);
     }
 
     private static class ReadOnlyDisplayPropertyMap extends DisplayPropertyMap {

--- a/src/com/dmdirc/ui/messages/EventFormat.java
+++ b/src/com/dmdirc/ui/messages/EventFormat.java
@@ -22,7 +22,7 @@
 
 package com.dmdirc.ui.messages;
 
-import com.dmdirc.util.colours.Colour;
+import com.dmdirc.events.DisplayPropertyMap;
 
 import com.google.auto.value.AutoValue;
 
@@ -42,18 +42,17 @@ public abstract class EventFormat {
     public abstract Optional<String> getAfterTemplate();
     /** The property that should be iterated over, if the event contains multiple lines. */
     public abstract Optional<String> getIterateProperty();
-
-    // TODO: This should probably be a generic set of properties.
-    public abstract Optional<Colour> getDefaultForegroundColour();
+    /** Display properties to use. */
+    public abstract DisplayPropertyMap getDisplayProperties();
 
     public static EventFormat create(
             final String template,
             final Optional<String> beforeTemplate,
             final Optional<String> afterTemplate,
             final Optional<String> iterateProperty,
-            final Optional<Colour> defaultForegroundColour) {
+            final DisplayPropertyMap displayProperties) {
         return new AutoValue_EventFormat(template, beforeTemplate, afterTemplate, iterateProperty,
-                defaultForegroundColour);
+                displayProperties);
     }
 
 }

--- a/src/com/dmdirc/ui/messages/EventFormatter.java
+++ b/src/com/dmdirc/ui/messages/EventFormatter.java
@@ -22,7 +22,6 @@
 
 package com.dmdirc.ui.messages;
 
-import com.dmdirc.events.DisplayProperty;
 import com.dmdirc.events.DisplayableEvent;
 
 import java.util.Optional;
@@ -59,12 +58,8 @@ public class EventFormatter {
 
     public Optional<String> format(final DisplayableEvent event) {
         final Optional<EventFormat> format = formatProvider.getFormat(event.getClass());
-
-        if (!event.hasDisplayProperty(DisplayProperty.FOREGROUND_COLOUR)) {
-            format.flatMap(EventFormat::getDefaultForegroundColour)
-                    .ifPresent(c -> event.setDisplayProperty(DisplayProperty.FOREGROUND_COLOUR, c));
-        }
-
+        format.map(EventFormat::getDisplayProperties)
+                .ifPresent(event.getDisplayProperties()::putAll);
         return format.map(f -> format(f, event));
     }
 

--- a/src/com/dmdirc/ui/messages/Line.java
+++ b/src/com/dmdirc/ui/messages/Line.java
@@ -66,7 +66,11 @@ public class Line {
      * @return Lines parts
      */
     public String[] getLineParts() {
-        return new String[] { timestamp, text };
+        if (displayProperties.get(DisplayProperty.NO_TIMESTAMPS).orElse(false)) {
+            return new String[] { text };
+        } else {
+            return new String[] { timestamp, text };
+        }
     }
 
     /**

--- a/src/com/dmdirc/ui/messages/YamlEventFormatProvider.java
+++ b/src/com/dmdirc/ui/messages/YamlEventFormatProvider.java
@@ -22,8 +22,9 @@
 
 package com.dmdirc.ui.messages;
 
+import com.dmdirc.events.DisplayProperty;
+import com.dmdirc.events.DisplayPropertyMap;
 import com.dmdirc.events.DisplayableEvent;
-import com.dmdirc.util.colours.Colour;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -102,12 +103,23 @@ public class YamlEventFormatProvider implements EventFormatProvider {
         final Optional<String> iterateProperty = info.containsKey("iterate")
                 ? Optional.of(info.get("iterate").toString())
                 : Optional.empty();
-        final Optional<Colour> foregroundColour = info.containsKey("colour")
-                ? Optional.of(colourManager.getColourFromIrcCode(
-                        Integer.parseInt(info.get("colour").toString())))
-                : Optional.empty();
         return EventFormat.create(
-                template, beforeTemplate, afterTemplate, iterateProperty, foregroundColour);
+                template, beforeTemplate, afterTemplate, iterateProperty,
+                getDisplayProperties(info));
+    }
+
+    private DisplayPropertyMap getDisplayProperties(final Map<Object, Object> info) {
+        final DisplayPropertyMap map = new DisplayPropertyMap();
+        if (info.containsKey("colour")) {
+            map.put(DisplayProperty.FOREGROUND_COLOUR,
+                    colourManager.getColourFromIrcCode(
+                            Integer.parseInt(info.get("colour").toString())));
+        }
+        if (info.containsKey("timestamp")) {
+            map.put(DisplayProperty.NO_TIMESTAMPS,
+                    !info.get("timestamp").toString().toLowerCase().matches("y|yes|true|1|on"));
+        }
+        return map;
     }
 
     @Override

--- a/test/com/dmdirc/ui/messages/EventFormatterTest.java
+++ b/test/com/dmdirc/ui/messages/EventFormatterTest.java
@@ -24,6 +24,7 @@ package com.dmdirc.ui.messages;
 
 import com.dmdirc.Channel;
 import com.dmdirc.events.ChannelMessageEvent;
+import com.dmdirc.events.DisplayPropertyMap;
 
 import java.util.Optional;
 
@@ -61,7 +62,7 @@ public class EventFormatterTest {
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
-                                Optional.empty())));
+                                new DisplayPropertyMap())));
         when(propertyManager.getProperty(messageEvent, ChannelMessageEvent.class, "channel"))
                 .thenReturn(Optional.of("MONKEY"));
 
@@ -79,7 +80,7 @@ public class EventFormatterTest {
                                 Optional.of("Before!"),
                                 Optional.of("After!"),
                                 Optional.empty(),
-                                Optional.empty())));
+                                new DisplayPropertyMap())));
         when(propertyManager.getProperty(messageEvent, ChannelMessageEvent.class, "channel"))
                 .thenReturn(Optional.of("MONKEY"));
 
@@ -99,7 +100,7 @@ public class EventFormatterTest {
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
-                                Optional.empty())));
+                                new DisplayPropertyMap())));
         when(propertyManager.getProperty(messageEvent, ChannelMessageEvent.class, "channel"))
                 .thenReturn(Optional.of("MONKEY"));
         when(propertyManager.applyFunction("MONKEY", "lowercase")).thenReturn("monkey");
@@ -118,7 +119,7 @@ public class EventFormatterTest {
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
-                                Optional.empty())));
+                                new DisplayPropertyMap())));
         when(propertyManager.getProperty(messageEvent, ChannelMessageEvent.class, "message"))
                 .thenReturn(Optional.of("{{channel}}"));
 


### PR DESCRIPTION
Formats defined in YAML can specify 'timestamps: false' to hide
the default timestamp for lines associated with that event.

Closes #633