### PR TITLE
Make the WindowManager track windows.

### DIFF
--- a/src/com/dmdirc/ui/WindowManager.java
+++ b/src/com/dmdirc/ui/WindowManager.java
@@ -30,8 +30,13 @@ import com.dmdirc.interfaces.WindowModel;
 import com.dmdirc.interfaces.ui.FrameListener;
 import com.dmdirc.util.collections.ListenerList;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -42,7 +47,6 @@ import net.engio.mbassy.listener.Handler;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
 
 /**
  * The WindowManager maintains a list of all open windows, and their parent/child relations.
@@ -52,6 +56,10 @@ public class WindowManager {
 
     /** A list of root windows. */
     private final Collection<WindowModel> rootWindows = new CopyOnWriteArrayList<>();
+    /** Mapping of windows to their parents. */
+    private final Map<WindowModel, WindowModel> parents = new HashMap<>();
+    /** Mapping of parents to their children. */
+    private final Multimap<WindowModel, WindowModel> children = ArrayListMultimap.create();
     /** A list of frame listeners. */
     private final ListenerList listeners = new ListenerList();
 
@@ -90,7 +98,7 @@ public class WindowManager {
         for (WindowModel root : rootWindows) {
             frameListener.addWindow(root, true);
 
-            for (WindowModel child : root.getChildren()) {
+            for (WindowModel child : getChildren(root)) {
                 fireAddWindow(frameListener, root, child);
             }
         }
@@ -108,7 +116,7 @@ public class WindowManager {
             final WindowModel parent, final WindowModel child) {
         listener.addWindow(parent, child, true);
 
-        for (WindowModel grandchild : child.getChildren()) {
+        for (WindowModel grandchild : getChildren(child)) {
             fireAddWindow(listener, child, grandchild);
         }
     }
@@ -120,6 +128,26 @@ public class WindowManager {
      */
     public void removeListener(final FrameListener frameListener) {
         listeners.remove(FrameListener.class, frameListener);
+    }
+
+    /**
+     * Gets the parent of the specified window, if there is one.
+     *
+     * @param window The window to find the parent of.
+     * @return The window's parent, if one exists.
+     */
+    public Optional<WindowModel> getParent(final WindowModel window) {
+        return Optional.ofNullable(parents.get(window));
+    }
+
+    /**
+     * Gets the collection of children belonging to the specified window.
+     *
+     * @param window The window to find the children on.
+     * @return A (possibly empty) collection of children of the given window.
+     */
+    public Collection<WindowModel> getChildren(final WindowModel window) {
+        return Collections.unmodifiableCollection(children.get(window));
     }
 
     /**
@@ -167,8 +195,7 @@ public class WindowManager {
      * @since 0.6.4
      */
     @Precondition("The specified Windows are not null")
-    public void addWindow(final WindowModel parent,
-            final WindowModel child) {
+    public void addWindow(final WindowModel parent, final WindowModel child) {
         addWindow(parent, child, true);
     }
 
@@ -186,13 +213,14 @@ public class WindowManager {
         "The specified parent is in the window hierarchy already",
         "The specified child is NOT in the window hierarchy already"
     })
-    public void addWindow(final WindowModel parent,
-            final WindowModel child, final boolean focus) {
+    public void addWindow(final WindowModel parent, final WindowModel child, final boolean focus) {
         checkNotNull(parent);
         checkArgument(isInHierarchy(parent));
         checkNotNull(child);
 
         parent.addChild(child);
+        parents.put(child, parent);
+        children.put(parent, child);
 
         fireAddWindow(parent, child, focus);
     }
@@ -207,12 +235,7 @@ public class WindowManager {
      * @return True if the target is in the hierarchy, false otherwise
      */
     protected boolean isInHierarchy(final WindowModel target) {
-        if (rootWindows.contains(target)) {
-            return true;
-        }
-
-        final Optional<WindowModel> parent = target.getParent();
-        return parent.isPresent() && isInHierarchy(parent.get());
+        return rootWindows.contains(target) || parents.containsKey(target);
     }
 
     /**
@@ -232,16 +255,17 @@ public class WindowManager {
         checkNotNull(window);
         checkArgument(isInHierarchy(window));
 
-        window.getChildren().forEach(WindowModel::close);
+        children.get(window).forEach(WindowModel::close);
+        children.removeAll(window);
 
         if (rootWindows.contains(window)) {
             fireDeleteWindow(window);
             rootWindows.remove(window);
         } else {
-            final Optional<WindowModel> parent = window.getParent();
-            checkState(parent.isPresent());
-            fireDeleteWindow(parent.get(), window);
-            parent.get().removeChild(window);
+            final WindowModel parent = parents.get(window);
+            fireDeleteWindow(parent, window);
+            parent.removeChild(window);
+            parents.remove(parent);
         }
     }
 
@@ -278,7 +302,7 @@ public class WindowManager {
         checkNotNull(parent);
         checkNotNull(name);
 
-        return findCustomWindow(parent.getChildren(), name);
+        return findCustomWindow(getChildren(parent), name);
     }
 
     /**
@@ -290,11 +314,9 @@ public class WindowManager {
      *
      * @return The custom window if found, or null otherwise
      */
-    private WindowModel findCustomWindow(final Iterable<WindowModel> windows,
-            final String name) {
+    private WindowModel findCustomWindow(final Iterable<WindowModel> windows, final String name) {
         for (WindowModel window : windows) {
-            if (window instanceof CustomWindow
-                    && window.getName().equals(name)) {
+            if (window instanceof CustomWindow && window.getName().equals(name)) {
                 return window;
             }
         }
@@ -356,8 +378,7 @@ public class WindowManager {
      * @param parent The parent window
      * @param child  The child window that was removed
      */
-    private void fireDeleteWindow(final WindowModel parent,
-            final WindowModel child) {
+    private void fireDeleteWindow(final WindowModel parent, final WindowModel child) {
         for (FrameListener listener : listeners.get(FrameListener.class)) {
             listener.delWindow(parent, child);
         }

--- a/test/com/dmdirc/ui/WindowManagerTest.java
+++ b/test/com/dmdirc/ui/WindowManagerTest.java
@@ -87,6 +87,30 @@ public class WindowManagerTest {
     }
 
     @Test
+    public void testGetParent() {
+        manager.addWindow(container);
+        manager.addListener(frameListener);
+        manager.addWindow(container, child);
+
+        assertEquals(Optional.of(container), manager.getParent(child));
+        assertEquals(Optional.empty(), manager.getParent(container));
+    }
+
+    @Test
+    public void testGetChildren() {
+        manager.addWindow(container);
+        manager.addListener(frameListener);
+        manager.addWindow(container, child);
+        manager.addWindow(container, grandchild);
+
+        assertEquals(2, manager.getChildren(container).size());
+        assertTrue(manager.getChildren(container).contains(child));
+        assertTrue(manager.getChildren(container).contains(grandchild));
+        assertEquals(0, manager.getChildren(child).size());
+        assertEquals(0, manager.getChildren(grandchild).size());
+    }
+
+    @Test
     public void testRemoveRoot() {
         manager.addWindow(container);
         manager.addListener(frameListener);
@@ -101,8 +125,6 @@ public class WindowManagerTest {
         manager.addWindow(container);
         manager.addWindow(container, child);
         manager.addListener(frameListener);
-
-        when(child.getParent()).thenReturn(Optional.of(container));
 
         manager.removeWindow(child);
 
@@ -134,10 +156,9 @@ public class WindowManagerTest {
 
     @Test
     public void testAddListenerAndSync() {
-        when(container.getChildren()).thenReturn(Arrays.asList(child));
-        when(child.getChildren()).thenReturn(Arrays.asList(grandchild));
-
         manager.addWindow(container);
+        manager.addWindow(container, child);
+        manager.addWindow(child, grandchild);
         manager.addListenerAndSync(frameListener);
 
         verify(frameListener).addWindow(container, true);
@@ -156,11 +177,9 @@ public class WindowManagerTest {
 
     @Test
     public void testRemoveWindowRootWindowWithChildren() {
-        when(container.getChildren()).thenReturn(Arrays.asList(child));
-        when(child.getParent()).thenReturn(Optional.of(container));
-
         manager.addListener(frameListener);
         manager.addWindow(container);
+        manager.addWindow(container, child);
         manager.removeWindow(container);
 
         verify(frameListener).delWindow(container);
@@ -169,11 +188,9 @@ public class WindowManagerTest {
 
     @Test
     public void testRemoveChildWindowNoChildren() {
-        when(container.getChildren()).thenReturn(Arrays.asList(child));
-        when(child.getParent()).thenReturn(Optional.of(container));
-
         manager.addListener(frameListener);
         manager.addWindow(container);
+        manager.addWindow(container, child);
         manager.removeWindow(child);
 
         verify(frameListener).delWindow(container, child);
@@ -182,12 +199,10 @@ public class WindowManagerTest {
 
     @Test
     public void testRemoveChildWindowWithChildren() {
-        when(container.getChildren()).thenReturn(Arrays.asList(child));
-        when(child.getChildren()).thenReturn(Arrays.asList(grandchild));
-        when(child.getParent()).thenReturn(Optional.of(container));
-
         manager.addListener(frameListener);
         manager.addWindow(container);
+        manager.addWindow(container, child);
+        manager.addWindow(child, grandchild);
         manager.removeWindow(child);
 
         verify(frameListener).delWindow(container, child);
@@ -236,8 +251,6 @@ public class WindowManagerTest {
 
         when(customContainer.getName()).thenReturn("test");
         when(customChild.getName()).thenReturn("test1");
-        when(customContainer.getChildren()).thenReturn(Arrays.asList(
-                new WindowModel[]{customChild, }));
 
         manager.addWindow(customContainer);
         manager.addWindow(customContainer, customChild);
@@ -252,8 +265,6 @@ public class WindowManagerTest {
 
         when(customContainer.getName()).thenReturn("test");
         when(customChild.getName()).thenReturn("test1");
-        when(customContainer.getChildren()).thenReturn(Arrays.asList(
-                new WindowModel[]{customChild, }));
 
         manager.addWindow(customContainer);
         manager.addWindow(customContainer, customChild);


### PR DESCRIPTION
Despite its name and description, the WindowManager relied on
each FrameContainer having a reference to its parents and all
its children.

The WindowManager now stores this information itself, and so
the FrameContainer methods can be gradually phased out.