### PR TITLE
Introduce a model for window input.

### DIFF
--- a/src/com/dmdirc/FrameContainer.java
+++ b/src/com/dmdirc/FrameContainer.java
@@ -29,6 +29,7 @@ import com.dmdirc.events.FrameComponentRemovedEvent;
 import com.dmdirc.events.FrameIconChangedEvent;
 import com.dmdirc.events.FrameNameChangedEvent;
 import com.dmdirc.events.FrameTitleChangedEvent;
+import com.dmdirc.interfaces.InputModel;
 import com.dmdirc.interfaces.WindowModel;
 import com.dmdirc.interfaces.config.AggregateConfigProvider;
 import com.dmdirc.interfaces.config.ConfigChangeListener;
@@ -54,7 +55,7 @@ import static com.google.common.base.Preconditions.checkState;
  * The frame container implements basic methods that should be present in all objects that handle a
  * frame.
  */
-public abstract class FrameContainer implements WindowModel {
+public abstract class FrameContainer implements WindowModel, InputModel {
 
     /** Listeners not yet using ListenerSupport. */
     protected final ListenerList listeners = new ListenerList();
@@ -345,6 +346,15 @@ public abstract class FrameContainer implements WindowModel {
     public void setCompositionState(final CompositionState state) {
         // Default implementation does nothing. Subclasses that support
         // composition should override this.
+    }
+
+    @Override
+    public Optional<InputModel> getInputModel() {
+        if (isWritable()) {
+            return Optional.of(this);
+        } else {
+            return Optional.empty();
+        }
     }
 
     @Override

--- a/src/com/dmdirc/interfaces/InputModel.java
+++ b/src/com/dmdirc/interfaces/InputModel.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006-2015 DMDirc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.dmdirc.interfaces;
+
+import com.dmdirc.commandparser.parsers.CommandParser;
+import com.dmdirc.ui.input.TabCompleter;
+
+/**
+ * Models the input functionality of a {@link WindowModel}.
+ */
+public interface InputModel {
+
+    /**
+     * Sends a line of text to the entity associated with the window.
+     *
+     * @param line The line to be sent
+     */
+    void sendLine(String line);
+
+    /**
+     * Retrieves the command parser to be used for input.
+     *
+     * @return This model's command parser
+     */
+    CommandParser getCommandParser();
+
+    /**
+     * Retrieves the tab completer which should be used for input.
+     *
+     * @return This model's tab completer
+     */
+    TabCompleter getTabCompleter();
+
+    /**
+     * Returns the maximum length that a line passed to {@link #sendLine(String)} should be, in
+     * order to prevent it being truncated or causing protocol violations.
+     *
+     * @return The maximum line length for this model
+     */
+    int getMaxLineLength();
+
+    /**
+     * Returns the number of lines that the specified string would be sent as, if it were passed
+     * to {@link #sendLine(String)}.
+     *
+     * @param line The string to be split and sent
+     * @return The number of lines required to send the specified string
+     */
+    int getNumLines(String line);
+
+}

--- a/src/com/dmdirc/interfaces/WindowModel.java
+++ b/src/com/dmdirc/interfaces/WindowModel.java
@@ -31,8 +31,6 @@ import com.dmdirc.ui.input.TabCompleter;
 import com.dmdirc.ui.messages.BackBuffer;
 import com.dmdirc.ui.messages.UnreadStatusManager;
 
-import java.util.Collection;
-import java.util.Date;
 import java.util.Optional;
 import java.util.Set;
 
@@ -148,6 +146,13 @@ public interface WindowModel {
      * @return The number of lines required to send the specified string
      */
     int getNumLines(String line);
+
+    /**
+     * Returns the model used to define input parameters for this window.
+     *
+     * @return If this window accepts input, the input model to use, otherwise an empty optional.
+     */
+    Optional<InputModel> getInputModel();
 
     UnreadStatusManager getUnreadStatusManager();
 }


### PR DESCRIPTION
Instead of WindowModel defining lots of methods on the off-chance
that the window is writable, pull them all into a separate
optional InputModel.

For ease of transition, FrameContainer will just implement both,
but eventually the input handling should be pulled out into
its own class.