### PR TITLE
Assign IDs to windows.

### DIFF
--- a/src/com/dmdirc/FrameContainer.java
+++ b/src/com/dmdirc/FrameContainer.java
@@ -82,6 +82,8 @@ public class FrameContainer implements WindowModel {
     private Optional<InputModel> inputModel = Optional.empty();
     /** The connection associated with this model. */
     private Optional<Connection> connection = Optional.empty();
+    /** The ID for this window. */
+    @Nullable private String id = null;
 
     /**
      * Instantiate new frame container.
@@ -113,6 +115,22 @@ public class FrameContainer implements WindowModel {
     protected void initBackBuffer() {
         backBuffer = backBufferFactory.getBackBuffer(this);
         backBuffer.startAddingEvents();
+    }
+
+    @Override
+    public String getId() {
+        if (this.id == null) {
+            throw new IllegalStateException("ID has not been set");
+        }
+        return id;
+    }
+
+    @Override
+    public void setId(@Nullable final String id) {
+        if (this.id != null) {
+            throw new IllegalStateException("ID already set");
+        }
+        this.id = id;
     }
 
     @Override

--- a/src/com/dmdirc/interfaces/WindowModel.java
+++ b/src/com/dmdirc/interfaces/WindowModel.java
@@ -38,6 +38,21 @@ import java.util.Set;
  */
 public interface WindowModel {
 
+    /**
+     * Gets a unique ID that identifies this window.
+     *
+     * @return This window's unique ID.
+     */
+    String getId();
+
+    /**
+     * Sets the ID for this window. This may only be called once; attempting to overwrite a
+     * previous ID will throw an exception.
+     *
+     * @param id The new ID for this window.
+     */
+    void setId(String id);
+
     String getIcon();
 
     String getName();

--- a/test/com/dmdirc/ui/WindowManagerTest.java
+++ b/test/com/dmdirc/ui/WindowManagerTest.java
@@ -33,11 +33,15 @@ import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyObject;
@@ -56,6 +60,7 @@ public class WindowManagerTest {
     @Mock private WindowModel child;
     @Mock private WindowModel grandchild;
     @Mock private DMDircMBassador eventBus;
+    @Captor private ArgumentCaptor<String> idCaptor;
     private WindowManager manager;
 
     @Before
@@ -269,4 +274,35 @@ public class WindowManagerTest {
 
         assertNull(manager.findCustomWindow(customContainer, "test"));
     }
+
+    @Test
+    public void testAssignId() {
+        manager.addWindow(container);
+        manager.addWindow(container, child);
+
+        verify(container).setId(idCaptor.capture());
+        final String parentId = idCaptor.getValue();
+
+        verify(child).setId(idCaptor.capture());
+        final String childId = idCaptor.getValue();
+
+        assertNotEquals(parentId, childId);
+    }
+
+    @Test
+    public void testGetById() {
+        manager.addWindow(container);
+        manager.addWindow(container, child);
+
+        verify(container).setId(idCaptor.capture());
+        final String parentId = idCaptor.getValue();
+
+        verify(child).setId(idCaptor.capture());
+        final String childId = idCaptor.getValue();
+
+        assertSame(container, manager.getWindowById(parentId).get());
+        assertSame(child, manager.getWindowById(childId).get());
+        assertEquals(Optional.empty(), manager.getWindowById("invalid"));
+    }
+
 }


### PR DESCRIPTION
This allows windows to be uniquely identified and shared with
clients that are running outside of the DMDirc process (e.g.
a web UI, or a remote instance).