### PR TITLE
Remove unused DisplayableEvent properties.

### DIFF
--- a/src/com/dmdirc/events/BaseDisplayableEvent.java
+++ b/src/com/dmdirc/events/BaseDisplayableEvent.java
@@ -25,15 +25,12 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.WindowModel;
 
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Base class for miscallenous displayable events.
  */
 public abstract class BaseDisplayableEvent extends DMDircEvent implements DisplayableEvent {
 
-    /** The display format to use for this event. */
-    private final AtomicReference<String> displayFormatRef = new AtomicReference<>("");
     /** The properties associated with this event. */
     private final DisplayPropertyMap properties = new DisplayPropertyMap();
     /** The frame container that caused this event. */
@@ -46,16 +43,6 @@ public abstract class BaseDisplayableEvent extends DMDircEvent implements Displa
 
     public BaseDisplayableEvent(final WindowModel source) {
         this.source = source;
-    }
-
-    @Override
-    public String getDisplayFormat() {
-        return displayFormatRef.get();
-    }
-
-    @Override
-    public void setDisplayFormat(final String format) {
-        displayFormatRef.set(format);
     }
 
     @Override

--- a/src/com/dmdirc/events/ChannelDisplayableEvent.java
+++ b/src/com/dmdirc/events/ChannelDisplayableEvent.java
@@ -26,15 +26,12 @@ import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.WindowModel;
 
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Base type for displayable events that occur in channels.
  */
 public abstract class ChannelDisplayableEvent extends ChannelEvent implements DisplayableEvent {
 
-    /** The display format to use for this event. */
-    private final AtomicReference<String> displayFormatRef = new AtomicReference<>("");
     /** The properties associated with this event. */
     private final DisplayPropertyMap properties = new DisplayPropertyMap();
 
@@ -44,16 +41,6 @@ public abstract class ChannelDisplayableEvent extends ChannelEvent implements Di
 
     public ChannelDisplayableEvent(final GroupChat channel) {
         super(channel);
-    }
-
-    @Override
-    public String getDisplayFormat() {
-        return displayFormatRef.get();
-    }
-
-    @Override
-    public void setDisplayFormat(final String format) {
-        displayFormatRef.set(format);
     }
 
     @Override

--- a/src/com/dmdirc/events/DisplayableEvent.java
+++ b/src/com/dmdirc/events/DisplayableEvent.java
@@ -32,20 +32,6 @@ import java.util.Optional;
 public interface DisplayableEvent {
 
     /**
-     * Gets the format name that will be used to display the event.
-     *
-     * @return The format name to use for the event.
-     */
-    String getDisplayFormat();
-
-    /**
-     * Sets the format name that should be used to display the event.
-     *
-     * @param format The format name to use for the event.
-     */
-    void setDisplayFormat(String format);
-
-    /**
      * Sets a property relating to how this event should be displayed.
      *
      * @param property The property to be set

--- a/src/com/dmdirc/events/QueryDisplayableEvent.java
+++ b/src/com/dmdirc/events/QueryDisplayableEvent.java
@@ -26,16 +26,12 @@ import com.dmdirc.Query;
 import com.dmdirc.interfaces.WindowModel;
 
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Base type for displayable events that occur in queries.
  */
-public abstract class QueryDisplayableEvent extends QueryEvent implements
-        DisplayableEvent {
+public abstract class QueryDisplayableEvent extends QueryEvent implements DisplayableEvent {
 
-    /** The display format to use for this event. */
-    private final AtomicReference<String> displayFormatRef = new AtomicReference<>("");
     /** The properties associated with this event. */
     private final DisplayPropertyMap properties = new DisplayPropertyMap();
 
@@ -45,16 +41,6 @@ public abstract class QueryDisplayableEvent extends QueryEvent implements
 
     public QueryDisplayableEvent(final Query query) {
         super(query);
-    }
-
-    @Override
-    public String getDisplayFormat() {
-        return displayFormatRef.get();
-    }
-
-    @Override
-    public void setDisplayFormat(final String format) {
-        displayFormatRef.set(format);
     }
 
     @Override

--- a/src/com/dmdirc/events/ServerDisplayableEvent.java
+++ b/src/com/dmdirc/events/ServerDisplayableEvent.java
@@ -26,7 +26,6 @@ import com.dmdirc.interfaces.Connection;
 import com.dmdirc.interfaces.WindowModel;
 
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 
 
 /**
@@ -34,8 +33,6 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public abstract class ServerDisplayableEvent extends ServerEvent implements DisplayableEvent {
 
-    /** The display format to use for this event. */
-    private final AtomicReference<String> displayFormatRef = new AtomicReference<>("");
     /** The properties associated with this event. */
     private final DisplayPropertyMap properties = new DisplayPropertyMap();
 
@@ -45,16 +42,6 @@ public abstract class ServerDisplayableEvent extends ServerEvent implements Disp
 
     public ServerDisplayableEvent(final Connection connection) {
         super(connection);
-    }
-
-    @Override
-    public String getDisplayFormat() {
-        return displayFormatRef.get();
-    }
-
-    @Override
-    public void setDisplayFormat(final String format) {
-        displayFormatRef.set(format);
     }
 
     @Override

--- a/src/com/dmdirc/events/UnknownCommandEvent.java
+++ b/src/com/dmdirc/events/UnknownCommandEvent.java
@@ -25,7 +25,6 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.WindowModel;
 
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.Nullable;
 
@@ -34,8 +33,6 @@ import javax.annotation.Nullable;
  */
 public class UnknownCommandEvent extends DMDircEvent implements DisplayableEvent {
 
-    /** The display format to use for this event. */
-    private final AtomicReference<String> displayFormatRef = new AtomicReference<>("");
     /** The properties associated with this event. */
     private final DisplayPropertyMap properties = new DisplayPropertyMap();
     @Nullable private final WindowModel source;
@@ -69,16 +66,6 @@ public class UnknownCommandEvent extends DMDircEvent implements DisplayableEvent
 
     public String[] getArguments() {
         return arguments;
-    }
-
-    @Override
-    public String getDisplayFormat() {
-        return displayFormatRef.get();
-    }
-
-    @Override
-    public void setDisplayFormat(final String format) {
-        displayFormatRef.set(format);
     }
 
     @Override

--- a/src/com/dmdirc/util/EventUtils.java
+++ b/src/com/dmdirc/util/EventUtils.java
@@ -22,8 +22,6 @@
 
 package com.dmdirc.util;
 
-import com.dmdirc.DMDircMBassador;
-import com.dmdirc.events.DMDircEvent;
 import com.dmdirc.events.DisplayableEvent;
 
 /**
@@ -44,26 +42,6 @@ public final class EventUtils {
     public static final int PRIORITY_DISPLAYABLE_EVENT_HANDLER = -1000;
 
     private EventUtils() {
-    }
-
-    /**
-     * Posts a displayable event to the bus, and returns the updated display format.
-     *
-     * @param <T>             The type of event to be displayed
-     *
-     * @param eventBus      The bus to post events to.
-     * @param event         The event to be posted.
-     * @param displayFormat The initial, default, display format.
-     *
-     * @return The event's display format after it has been posted on the event bus.
-     */
-    public static <T extends DMDircEvent & DisplayableEvent> String postDisplayable(
-            final DMDircMBassador eventBus,
-            final T event,
-            final String displayFormat) {
-        event.setDisplayFormat(displayFormat);
-        eventBus.publish(event);
-        return event.getDisplayFormat();
     }
 
 }


### PR DESCRIPTION
Now everything is using events, we don't need the legacy
format identifier.