### PR TITLE
Convert events to use new date APIs.

### DIFF
--- a/src/com/dmdirc/ChannelEventHandler.java
+++ b/src/com/dmdirc/ChannelEventHandler.java
@@ -59,6 +59,8 @@ import com.dmdirc.parser.interfaces.Parser;
 
 import com.google.common.base.Strings;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -109,8 +111,10 @@ public class ChannelEventHandler extends EventHandler {
             return;
         }
 
-        eventBus.publishAsync(new ChannelMessageEvent(event.getDate().getTime(), owner,
-                groupChatUserManager.getUserFromClient(event.getClient(), owner), event.getMessage()));
+        eventBus.publishAsync(new ChannelMessageEvent(
+                LocalDateTime.ofInstant(event.getDate().toInstant(), ZoneId.systemDefault()),
+                owner, groupChatUserManager.getUserFromClient(event.getClient(), owner),
+                event.getMessage()));
     }
 
     @Handler
@@ -122,7 +126,9 @@ public class ChannelEventHandler extends EventHandler {
         owner.setClients(event.getChannel().getChannelClients().stream()
                 .map(client -> groupChatUserManager.getUserFromClient(client, owner))
                 .collect(Collectors.toList()));
-        eventBus.publishAsync(new ChannelGotNamesEvent(event.getDate().getTime(), owner));
+        eventBus.publishAsync(new ChannelGotNamesEvent(
+                LocalDateTime.ofInstant(event.getDate().toInstant(), ZoneId.systemDefault()),
+                owner));
     }
 
     @Handler
@@ -132,7 +138,8 @@ public class ChannelEventHandler extends EventHandler {
         }
 
         final ChannelInfo channel = event.getChannel();
-        final Date date = event.getDate();
+        final LocalDateTime date = LocalDateTime.ofInstant(
+                event.getDate().toInstant(), ZoneId.systemDefault());
 
         final Topic topic = Topic.create(channel.getTopic(),
                 owner.getUser(getConnection().getUser(channel.getTopicSetter())).orElse(null),
@@ -147,11 +154,11 @@ public class ChannelEventHandler extends EventHandler {
             }
         } else {
             if (Strings.isNullOrEmpty(channel.getTopic())) {
-                eventBus.publishAsync(new ChannelTopicUnsetEvent(date.getTime(), owner,
+                eventBus.publishAsync(new ChannelTopicUnsetEvent(date, owner,
                         owner.getUser(owner.getConnection().get()
                                 .getUser(channel.getTopicSetter())).orElse(null)));
             } else {
-                eventBus.publishAsync(new ChannelTopicChangeEvent(date.getTime(), owner, topic,
+                eventBus.publishAsync(new ChannelTopicChangeEvent(date, owner, topic,
                         topic.getClient().get()));
 
             }
@@ -177,7 +184,8 @@ public class ChannelEventHandler extends EventHandler {
             return;
         }
 
-        eventBus.publish(new ChannelJoinEvent(event.getDate().getTime(), owner,
+        eventBus.publish(new ChannelJoinEvent(
+                LocalDateTime.ofInstant(event.getDate().toInstant(), ZoneId.systemDefault()), owner,
                 groupChatUserManager.getUserFromClient(event.getClient(), owner)));
         owner.addClient(groupChatUserManager.getUserFromClient(event.getClient(), owner));
     }
@@ -189,14 +197,15 @@ public class ChannelEventHandler extends EventHandler {
         }
 
         final ChannelClientInfo client = event.getClient();
-        final Date date = event.getDate();
+        final LocalDateTime date =
+                LocalDateTime.ofInstant(event.getDate().toInstant(), ZoneId.systemDefault());
         final String reason = event.getReason();
 
         if (isMyself(client)) {
-            eventBus.publishAsync(new ChannelSelfPartEvent(date.getTime(), owner,
+            eventBus.publishAsync(new ChannelSelfPartEvent(date, owner,
                     groupChatUserManager.getUserFromClient(client, owner), reason));
         } else {
-            eventBus.publishAsync(new ChannelPartEvent(date.getTime(), owner,
+            eventBus.publishAsync(new ChannelPartEvent(date, owner,
                     groupChatUserManager.getUserFromClient(client, owner), reason));
         }
         owner.removeClient(groupChatUserManager.getUserFromClient(client, owner));
@@ -209,7 +218,8 @@ public class ChannelEventHandler extends EventHandler {
         }
         final ChannelClientInfo kickedClient = event.getKickedClient();
 
-        eventBus.publishAsync(new ChannelKickEvent(event.getDate().getTime(), owner,
+        eventBus.publishAsync(new ChannelKickEvent(
+                LocalDateTime.ofInstant(event.getDate().toInstant(), ZoneId.systemDefault()), owner,
                 groupChatUserManager.getUserFromClient(event.getClient(), owner),
                 groupChatUserManager.getUserFromClient(kickedClient, owner), event.getReason()));
         owner.removeClient(groupChatUserManager.getUserFromClient(kickedClient, owner));
@@ -221,8 +231,10 @@ public class ChannelEventHandler extends EventHandler {
             return;
         }
 
-        eventBus.publishAsync(new ChannelQuitEvent(event.getDate().getTime(), owner,
-                groupChatUserManager.getUserFromClient(event.getClient(), owner), event.getReason()));
+        eventBus.publishAsync(new ChannelQuitEvent(
+                LocalDateTime.ofInstant(event.getDate().toInstant(), ZoneId.systemDefault()), owner,
+                groupChatUserManager.getUserFromClient(event.getClient(), owner),
+                event.getReason()));
         owner.removeClient(groupChatUserManager.getUserFromClient(event.getClient(), owner));
     }
 
@@ -232,8 +244,10 @@ public class ChannelEventHandler extends EventHandler {
             return;
         }
 
-        eventBus.publishAsync(new ChannelActionEvent(event.getDate().getTime(), owner,
-                groupChatUserManager.getUserFromClient(event.getClient(), owner), event.getMessage()));
+        eventBus.publishAsync(new ChannelActionEvent(
+                LocalDateTime.ofInstant(event.getDate().toInstant(), ZoneId.systemDefault()), owner,
+                groupChatUserManager.getUserFromClient(event.getClient(), owner),
+                event.getMessage()));
     }
 
     @Handler
@@ -249,12 +263,16 @@ public class ChannelEventHandler extends EventHandler {
 
         if (isMyself(client)) {
             eventBus.publishAsync(
-                    new ChannelSelfNickChangeEvent(event.getDate().getTime(), owner,
-                            groupChatUserManager.getUserFromClient(client, owner), oldNick));
+                    new ChannelSelfNickChangeEvent(
+                            LocalDateTime.ofInstant(
+                                    event.getDate().toInstant(), ZoneId.systemDefault()),
+                            owner, groupChatUserManager.getUserFromClient(client, owner), oldNick));
         } else {
             eventBus.publishAsync(
-                    new ChannelNickChangeEvent(event.getDate().getTime(), owner,
-                            groupChatUserManager.getUserFromClient(client, owner), oldNick));
+                    new ChannelNickChangeEvent(
+                            LocalDateTime.ofInstant(
+                                    event.getDate().toInstant(), ZoneId.systemDefault()),
+                            owner, groupChatUserManager.getUserFromClient(client, owner), oldNick));
         }
     }
 
@@ -267,20 +285,21 @@ public class ChannelEventHandler extends EventHandler {
         final String host = event.getHost();
         final String modes = event.getModes();
         final ChannelClientInfo client = event.getClient();
-        final Date date = event.getDate();
+        final LocalDateTime date = LocalDateTime.ofInstant(event.getDate().toInstant(),
+                ZoneId.systemDefault());
 
         if (host.isEmpty()) {
             if (modes.length() <= 1) {
-                eventBus.publishAsync(new ChannelNoModesDiscoveredEvent(date.getTime(), owner));
+                eventBus.publishAsync(new ChannelNoModesDiscoveredEvent(date, owner));
             } else {
                 eventBus.publishAsync(
-                        new ChannelModesDiscoveredEvent(date.getTime(), owner,modes));
+                        new ChannelModesDiscoveredEvent(date, owner,modes));
             }
         } else if (isMyself(client)) {
-            eventBus.publishAsync(new ChannelSelfModeChangeEvent(date.getTime(), owner,
+            eventBus.publishAsync(new ChannelSelfModeChangeEvent(date, owner,
                     groupChatUserManager.getUserFromClient(client, owner), modes));
         } else {
-            eventBus.publishAsync(new ChannelModeChangeEvent(date.getTime(), owner,
+            eventBus.publishAsync(new ChannelModeChangeEvent(date, owner,
                     groupChatUserManager.getUserFromClient(client, owner), modes));
         }
 
@@ -295,10 +314,11 @@ public class ChannelEventHandler extends EventHandler {
 
         final ChannelClientInfo client = event.getClient();
         final String message = event.getMessage();
-        final Date date = event.getDate();
+        final LocalDateTime date = LocalDateTime.ofInstant(event.getDate().toInstant(),
+                ZoneId.systemDefault());
         final String type = event.getType();
 
-        final ChannelCtcpEvent coreEvent = new ChannelCtcpEvent(date.getTime(), owner,
+        final ChannelCtcpEvent coreEvent = new ChannelCtcpEvent(date, owner,
                 groupChatUserManager.getUserFromClient(client, owner),type, message);
         eventBus.publish(coreEvent);
         if (!coreEvent.isHandled()) {
@@ -312,10 +332,14 @@ public class ChannelEventHandler extends EventHandler {
                 .ifPresent(c -> {
                     if (event.getNewState() == AwayState.AWAY) {
                         eventBus.publishAsync(
-                                new ChannelUserAwayEvent(event.getDate().getTime(), owner, c));
+                                new ChannelUserAwayEvent(LocalDateTime.ofInstant(
+                                        event.getDate().toInstant(), ZoneId.systemDefault()),
+                                        owner, c));
                     } else {
                         eventBus.publishAsync(
-                                new ChannelUserBackEvent(event.getDate().getTime(), owner, c));
+                                new ChannelUserBackEvent(
+                                        LocalDateTime.ofInstant(event.getDate().toInstant(),
+                                                ZoneId.systemDefault()), owner, c));
                     }
                 });
     }
@@ -326,8 +350,10 @@ public class ChannelEventHandler extends EventHandler {
             return;
         }
 
-        eventBus.publishAsync(new ChannelNoticeEvent(event.getDate().getTime(), owner,
-                groupChatUserManager.getUserFromClient(event.getClient(), owner), event.getMessage()));
+        eventBus.publishAsync(new ChannelNoticeEvent(
+                LocalDateTime.ofInstant(event.getDate().toInstant(), ZoneId.systemDefault()), owner,
+                groupChatUserManager.getUserFromClient(event.getClient(), owner),
+                event.getMessage()));
     }
 
     @Handler
@@ -336,7 +362,9 @@ public class ChannelEventHandler extends EventHandler {
             return;
         }
 
-        eventBus.publishAsync(new ChannelModeNoticeEvent(event.getDate().getTime(), owner,
+        eventBus.publishAsync(new ChannelModeNoticeEvent(
+                LocalDateTime.ofInstant(event.getDate().toInstant(), ZoneId.systemDefault()),
+                owner,
                 groupChatUserManager.getUserFromClient(event.getClient(), owner), String.valueOf
                 (event.getPrefix()), event.getMessage()));
     }
@@ -348,7 +376,8 @@ public class ChannelEventHandler extends EventHandler {
         }
 
         eventBus.publishAsync(new ChannelListModesRetrievedEvent(
-                event.getDate().getTime(), owner, event.getMode()));
+                LocalDateTime.ofInstant(event.getDate().toInstant(), ZoneId.systemDefault()),
+                owner, event.getMode()));
     }
 
     private boolean checkChannel(final ChannelInfo channelInfo) {

--- a/src/com/dmdirc/ServerEventHandler.java
+++ b/src/com/dmdirc/ServerEventHandler.java
@@ -87,6 +87,8 @@ import com.dmdirc.parser.events.WallopEvent;
 import com.dmdirc.parser.events.WalluserEvent;
 import com.dmdirc.ui.StatusMessage;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
@@ -155,8 +157,9 @@ public class ServerEventHandler extends EventHandler {
 
     @Handler
     public void onWhoisEvent(final UserInfoEvent event) {
-        eventBus.publishAsync(new UserInfoResponseEvent(owner, event.getDate().getTime(),
-                owner.getUser(event.getClient().getNickname()), event.getInfo()));
+        eventBus.publishAsync(new UserInfoResponseEvent(
+                LocalDateTime.ofInstant(event.getDate().toInstant(), ZoneId.systemDefault()),
+                owner, owner.getUser(event.getClient().getNickname()), event.getInfo()));
     }
 
     @SuppressWarnings("ThrowableResultOfMethodCallIgnored")

--- a/src/com/dmdirc/commandparser/commands/global/Echo.java
+++ b/src/com/dmdirc/commandparser/commands/global/Echo.java
@@ -40,6 +40,8 @@ import com.dmdirc.interfaces.WindowModel;
 import com.dmdirc.ui.WindowManager;
 import com.dmdirc.ui.input.AdditionalTabTargets;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -119,12 +121,14 @@ public class Echo extends Command implements IntelligentCommand {
             if (frame == null) {
                 showError(origin, args.isSilent(), "Unable to find target window");
             } else if (!args.isSilent()) {
-                frame.getEventBus().publishAsync(new CommandOutputEvent(frame, time.getTime(),
-                        results.getArgumentsAsString()));
+                frame.getEventBus().publishAsync(new CommandOutputEvent(
+                        LocalDateTime.ofInstant(time.toInstant(), ZoneId.systemDefault()),
+                        frame, results.getArgumentsAsString()));
             }
         } else if (!args.isSilent()) {
-            origin.getEventBus().publishAsync(new CommandOutputEvent(origin,
-                    time.getTime(), results.getArgumentsAsString()));
+            origin.getEventBus().publishAsync(new CommandOutputEvent(
+                    LocalDateTime.ofInstant(time.toInstant(), ZoneId.systemDefault()), origin,
+                    results.getArgumentsAsString()));
         }
     }
 

--- a/src/com/dmdirc/events/BaseChannelActionEvent.java
+++ b/src/com/dmdirc/events/BaseChannelActionEvent.java
@@ -25,12 +25,14 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Base class for channel action events.
  */
 public class BaseChannelActionEvent extends BaseChannelTextEvent {
 
-    public BaseChannelActionEvent(final long timestamp, final GroupChat channel,
+    public BaseChannelActionEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser client, final String message) {
         super(timestamp, channel, client, message);
     }

--- a/src/com/dmdirc/events/BaseChannelMessageEvent.java
+++ b/src/com/dmdirc/events/BaseChannelMessageEvent.java
@@ -25,12 +25,14 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Base channel message event.
  */
 public class BaseChannelMessageEvent extends BaseChannelTextEvent {
 
-    public BaseChannelMessageEvent(final long timestamp, final GroupChat channel,
+    public BaseChannelMessageEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser client, final String message) {
         super(timestamp, channel, client, message);
     }

--- a/src/com/dmdirc/events/BaseChannelTextEvent.java
+++ b/src/com/dmdirc/events/BaseChannelTextEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Base class for channel text events.
  */
@@ -33,7 +35,7 @@ public class BaseChannelTextEvent extends ChannelDisplayableEvent {
     private final GroupChatUser client;
     private final String message;
 
-    public BaseChannelTextEvent(final long timestamp, final GroupChat channel,
+    public BaseChannelTextEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser client, final String message) {
         super(timestamp, channel);
         this.client = client;

--- a/src/com/dmdirc/events/BaseDisplayableEvent.java
+++ b/src/com/dmdirc/events/BaseDisplayableEvent.java
@@ -24,6 +24,7 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.WindowModel;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 /**
@@ -36,7 +37,7 @@ public abstract class BaseDisplayableEvent extends DMDircEvent implements Displa
     /** The frame container that caused this event. */
     private final WindowModel source;
 
-    public BaseDisplayableEvent(final long timestamp, final WindowModel source) {
+    public BaseDisplayableEvent(final LocalDateTime timestamp, final WindowModel source) {
         super(timestamp);
         this.source = source;
     }

--- a/src/com/dmdirc/events/BaseQueryActionEvent.java
+++ b/src/com/dmdirc/events/BaseQueryActionEvent.java
@@ -25,12 +25,14 @@ package com.dmdirc.events;
 import com.dmdirc.Query;
 import com.dmdirc.interfaces.User;
 
+import java.time.LocalDateTime;
+
 /**
  * Base class for query action events.
  */
 public abstract class BaseQueryActionEvent extends BaseQueryTextEvent {
 
-    public BaseQueryActionEvent(final long timestamp, final Query query, final User user,
+    public BaseQueryActionEvent(final LocalDateTime timestamp, final Query query, final User user,
             final String message) {
         super(timestamp, query, user, message);
     }

--- a/src/com/dmdirc/events/BaseQueryMessageEvent.java
+++ b/src/com/dmdirc/events/BaseQueryMessageEvent.java
@@ -25,12 +25,14 @@ package com.dmdirc.events;
 import com.dmdirc.Query;
 import com.dmdirc.interfaces.User;
 
+import java.time.LocalDateTime;
+
 /**
  * Base class for query message events.
  */
 public abstract class BaseQueryMessageEvent extends BaseQueryTextEvent {
 
-    public BaseQueryMessageEvent(final long timestamp, final Query query, final User user,
+    public BaseQueryMessageEvent(final LocalDateTime timestamp, final Query query, final User user,
             final String message) {
         super(timestamp, query, user, message);
     }

--- a/src/com/dmdirc/events/BaseQueryTextEvent.java
+++ b/src/com/dmdirc/events/BaseQueryTextEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.Query;
 import com.dmdirc.interfaces.User;
 
+import java.time.LocalDateTime;
+
 /**
  * Base class for query message and action events.
  */
@@ -33,7 +35,7 @@ public abstract class BaseQueryTextEvent extends QueryDisplayableEvent {
     private final User user;
     private final String message;
 
-    public BaseQueryTextEvent(final long timestamp, final Query query, final User user,
+    public BaseQueryTextEvent(final LocalDateTime timestamp, final Query query, final User user,
             final String message) {
         super(timestamp, query);
         this.user = user;

--- a/src/com/dmdirc/events/ChannelActionEvent.java
+++ b/src/com/dmdirc/events/ChannelActionEvent.java
@@ -25,12 +25,14 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a channel action occurs.
  */
 public class ChannelActionEvent extends BaseChannelActionEvent {
 
-    public ChannelActionEvent(final long timestamp, final GroupChat channel,
+    public ChannelActionEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser client, final String message) {
         super(timestamp, channel, client, message);
     }

--- a/src/com/dmdirc/events/ChannelCtcpEvent.java
+++ b/src/com/dmdirc/events/ChannelCtcpEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired on receiving a channel CTCP request.
  */
@@ -35,7 +37,7 @@ public class ChannelCtcpEvent extends ChannelDisplayableEvent {
     private final String message;
     private boolean handled;
 
-    public ChannelCtcpEvent(final long timestamp, final GroupChat channel,
+    public ChannelCtcpEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser client, final String type, final String message) {
         super(timestamp, channel);
         this.client = client;

--- a/src/com/dmdirc/events/ChannelDisplayableEvent.java
+++ b/src/com/dmdirc/events/ChannelDisplayableEvent.java
@@ -25,6 +25,7 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.WindowModel;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 /**
@@ -35,7 +36,7 @@ public abstract class ChannelDisplayableEvent extends ChannelEvent implements Di
     /** The properties associated with this event. */
     private final DisplayPropertyMap properties = new DisplayPropertyMap();
 
-    public ChannelDisplayableEvent(final long timestamp, final GroupChat channel) {
+    public ChannelDisplayableEvent(final LocalDateTime timestamp, final GroupChat channel) {
         super(timestamp, channel);
     }
 

--- a/src/com/dmdirc/events/ChannelDisplayableUserEvent.java
+++ b/src/com/dmdirc/events/ChannelDisplayableUserEvent.java
@@ -25,12 +25,14 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Base type for displayable events that occur in channels against users.
  */
 public abstract class ChannelDisplayableUserEvent extends ChannelUserEvent {
 
-    public ChannelDisplayableUserEvent(final long timestamp, final GroupChat channel,
+    public ChannelDisplayableUserEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser user) {
         super(timestamp, channel, user);
     }

--- a/src/com/dmdirc/events/ChannelEvent.java
+++ b/src/com/dmdirc/events/ChannelEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.GroupChat;
 
+import java.time.LocalDateTime;
+
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -34,7 +36,7 @@ public abstract class ChannelEvent extends DMDircEvent {
     /** The group chat that this event occurred on. */
     private final GroupChat groupChat;
 
-    public ChannelEvent(final long timestamp, final GroupChat groupChat) {
+    public ChannelEvent(final LocalDateTime timestamp, final GroupChat groupChat) {
         super(timestamp);
         this.groupChat = checkNotNull(groupChat);
     }

--- a/src/com/dmdirc/events/ChannelGotNamesEvent.java
+++ b/src/com/dmdirc/events/ChannelGotNamesEvent.java
@@ -24,12 +24,14 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.GroupChat;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a channel names event is received.
  */
 public class ChannelGotNamesEvent extends ChannelEvent {
 
-    public ChannelGotNamesEvent(final long timestamp, final GroupChat channel) {
+    public ChannelGotNamesEvent(final LocalDateTime timestamp, final GroupChat channel) {
         super(timestamp, channel);
     }
 

--- a/src/com/dmdirc/events/ChannelGotTopicEvent.java
+++ b/src/com/dmdirc/events/ChannelGotTopicEvent.java
@@ -26,6 +26,8 @@ import com.dmdirc.Topic;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.User;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a channel topic is changed.
  */
@@ -34,8 +36,8 @@ public class ChannelGotTopicEvent extends ChannelDisplayableEvent {
     private final Topic topic;
     private final User user;
 
-    public ChannelGotTopicEvent(final long timestamp, final GroupChat channel, final Topic topic,
-            final User user) {
+    public ChannelGotTopicEvent(final LocalDateTime timestamp, final GroupChat channel,
+            final Topic topic, final User user) {
         super(timestamp, channel);
         this.topic = topic;
         this.user = user;

--- a/src/com/dmdirc/events/ChannelJoinEvent.java
+++ b/src/com/dmdirc/events/ChannelJoinEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a user joins a channel.
  */
@@ -32,7 +34,7 @@ public class ChannelJoinEvent extends ChannelDisplayableEvent {
 
     private final GroupChatUser client;
 
-    public ChannelJoinEvent(final long timestamp, final GroupChat channel,
+    public ChannelJoinEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser client) {
         super(timestamp, channel);
         this.client = client;

--- a/src/com/dmdirc/events/ChannelKickEvent.java
+++ b/src/com/dmdirc/events/ChannelKickEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a user is kicked from a channel.
  */
@@ -34,7 +36,7 @@ public class ChannelKickEvent extends ChannelDisplayableEvent {
     private final GroupChatUser victim;
     private final String reason;
 
-    public ChannelKickEvent(final long timestamp, final GroupChat channel,
+    public ChannelKickEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser client, final GroupChatUser victim, final String reason) {
         super(timestamp, channel);
         this.client = client;

--- a/src/com/dmdirc/events/ChannelListModesRetrievedEvent.java
+++ b/src/com/dmdirc/events/ChannelListModesRetrievedEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.GroupChat;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when channel list modes are retrieved.
  */
@@ -31,7 +33,7 @@ public class ChannelListModesRetrievedEvent extends ChannelEvent {
 
     private final char mode;
 
-    public ChannelListModesRetrievedEvent(final long timestamp, final GroupChat channel,
+    public ChannelListModesRetrievedEvent(final LocalDateTime timestamp, final GroupChat channel,
             final char mode) {
         super(timestamp, channel);
         this.mode = mode;

--- a/src/com/dmdirc/events/ChannelMessageEvent.java
+++ b/src/com/dmdirc/events/ChannelMessageEvent.java
@@ -25,12 +25,14 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a channel message occurs.
  */
 public class ChannelMessageEvent extends BaseChannelMessageEvent {
 
-    public ChannelMessageEvent(final long timestamp, final GroupChat channel,
+    public ChannelMessageEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser client, final String message) {
         super(timestamp, channel, client, message);
     }

--- a/src/com/dmdirc/events/ChannelModeChangeEvent.java
+++ b/src/com/dmdirc/events/ChannelModeChangeEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a channel mode is changed.
  */
@@ -33,7 +35,7 @@ public class ChannelModeChangeEvent extends ChannelDisplayableEvent {
     private final GroupChatUser client;
     private final String modes;
 
-    public ChannelModeChangeEvent(final long timestamp, final GroupChat channel,
+    public ChannelModeChangeEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser client, final String modes) {
         super(timestamp, channel);
         this.client = client;

--- a/src/com/dmdirc/events/ChannelModeNoticeEvent.java
+++ b/src/com/dmdirc/events/ChannelModeNoticeEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a channel mode is received.
  */
@@ -34,7 +36,7 @@ public class ChannelModeNoticeEvent extends ChannelDisplayableEvent {
     private final String prefix;
     private final String message;
 
-    public ChannelModeNoticeEvent(final long timestamp, final GroupChat channel,
+    public ChannelModeNoticeEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser client, final String prefix, final String message) {
         super(timestamp, channel);
         this.client = client;

--- a/src/com/dmdirc/events/ChannelModesDiscoveredEvent.java
+++ b/src/com/dmdirc/events/ChannelModesDiscoveredEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.GroupChat;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when channel modes are discovered.
  */
@@ -31,7 +33,7 @@ public class ChannelModesDiscoveredEvent extends ChannelDisplayableEvent {
 
     private final String modes;
 
-    public ChannelModesDiscoveredEvent(final long timestamp, final GroupChat channel,
+    public ChannelModesDiscoveredEvent(final LocalDateTime timestamp, final GroupChat channel,
             final String modes) {
         super(timestamp, channel);
         this.modes = modes;

--- a/src/com/dmdirc/events/ChannelNickChangeEvent.java
+++ b/src/com/dmdirc/events/ChannelNickChangeEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a user changes nickname in a channel.
  */
@@ -33,7 +35,7 @@ public class ChannelNickChangeEvent extends ChannelDisplayableEvent {
     private final GroupChatUser client;
     private final String oldNick;
 
-    public ChannelNickChangeEvent(final long timestamp, final GroupChat channel,
+    public ChannelNickChangeEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser client, final String oldNick) {
         super(timestamp, channel);
         this.client = client;

--- a/src/com/dmdirc/events/ChannelNoModesDiscoveredEvent.java
+++ b/src/com/dmdirc/events/ChannelNoModesDiscoveredEvent.java
@@ -24,12 +24,14 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.GroupChat;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when channel mode discovery is complete and there are no modes on the channel.
  */
 public class ChannelNoModesDiscoveredEvent extends ChannelDisplayableEvent {
 
-    public ChannelNoModesDiscoveredEvent(final long timestamp, final GroupChat channel) {
+    public ChannelNoModesDiscoveredEvent(final LocalDateTime timestamp, final GroupChat channel) {
         super(timestamp, channel);
     }
 

--- a/src/com/dmdirc/events/ChannelNoTopicEvent.java
+++ b/src/com/dmdirc/events/ChannelNoTopicEvent.java
@@ -24,12 +24,14 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.GroupChat;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a topic is unset on a channel.
  */
 public class ChannelNoTopicEvent extends ChannelDisplayableEvent {
 
-    public ChannelNoTopicEvent(final long timestamp, final GroupChat channel) {
+    public ChannelNoTopicEvent(final LocalDateTime timestamp, final GroupChat channel) {
         super(timestamp, channel);
     }
 

--- a/src/com/dmdirc/events/ChannelNoticeEvent.java
+++ b/src/com/dmdirc/events/ChannelNoticeEvent.java
@@ -25,12 +25,14 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a channel mode is received.
  */
 public class ChannelNoticeEvent extends BaseChannelTextEvent {
 
-    public ChannelNoticeEvent(final long timestamp, final GroupChat channel,
+    public ChannelNoticeEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser client, final String message) {
         super(timestamp, channel, client, message);
     }

--- a/src/com/dmdirc/events/ChannelPartEvent.java
+++ b/src/com/dmdirc/events/ChannelPartEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a user parts a channel.
  */
@@ -33,7 +35,7 @@ public class ChannelPartEvent extends ChannelDisplayableEvent {
     private final GroupChatUser client;
     private final String message;
 
-    public ChannelPartEvent(final long timestamp, final GroupChat channel,
+    public ChannelPartEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser client, final String message) {
         super(timestamp, channel);
         this.client = client;

--- a/src/com/dmdirc/events/ChannelQuitEvent.java
+++ b/src/com/dmdirc/events/ChannelQuitEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a user quits in a channel.
  */
@@ -33,7 +35,7 @@ public class ChannelQuitEvent extends ChannelDisplayableEvent {
     private final GroupChatUser client;
     private final String message;
 
-    public ChannelQuitEvent(final long timestamp, final GroupChat channel,
+    public ChannelQuitEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser client, final String message) {
         super(timestamp, channel);
         this.client = client;

--- a/src/com/dmdirc/events/ChannelSelfActionEvent.java
+++ b/src/com/dmdirc/events/ChannelSelfActionEvent.java
@@ -25,12 +25,14 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a channel self action occurs.
  */
 public class ChannelSelfActionEvent extends BaseChannelActionEvent {
 
-    public ChannelSelfActionEvent(final long timestamp, final GroupChat channel,
+    public ChannelSelfActionEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser client, final String message) {
         super(timestamp, channel, client, message);
     }

--- a/src/com/dmdirc/events/ChannelSelfJoinEvent.java
+++ b/src/com/dmdirc/events/ChannelSelfJoinEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.User;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when the local user joins a channel.
  */
@@ -32,7 +34,7 @@ public class ChannelSelfJoinEvent extends ChannelDisplayableEvent {
 
     private final User client;
 
-    public ChannelSelfJoinEvent(final long timestamp, final GroupChat channel,
+    public ChannelSelfJoinEvent(final LocalDateTime timestamp, final GroupChat channel,
             final User client) {
         super(timestamp, channel);
         this.client = client;

--- a/src/com/dmdirc/events/ChannelSelfMessageEvent.java
+++ b/src/com/dmdirc/events/ChannelSelfMessageEvent.java
@@ -25,12 +25,14 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a channel self message occurs.
  */
 public class ChannelSelfMessageEvent extends BaseChannelMessageEvent {
 
-    public ChannelSelfMessageEvent(final long timestamp, final GroupChat channel,
+    public ChannelSelfMessageEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser client, final String message) {
         super(timestamp, channel, client, message);
     }

--- a/src/com/dmdirc/events/ChannelSelfModeChangeEvent.java
+++ b/src/com/dmdirc/events/ChannelSelfModeChangeEvent.java
@@ -25,12 +25,14 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Event raised when the local client changes a channel mode.
  */
 public class ChannelSelfModeChangeEvent extends ChannelModeChangeEvent {
 
-    public ChannelSelfModeChangeEvent(final long timestamp, final GroupChat channel,
+    public ChannelSelfModeChangeEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser client, final String modes) {
         super(timestamp, channel, client, modes);
     }

--- a/src/com/dmdirc/events/ChannelSelfNickChangeEvent.java
+++ b/src/com/dmdirc/events/ChannelSelfNickChangeEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when the local user changes nickname in a channel.
  */
@@ -33,7 +35,7 @@ public class ChannelSelfNickChangeEvent extends ChannelDisplayableEvent {
     private final GroupChatUser client;
     private final String oldNick;
 
-    public ChannelSelfNickChangeEvent(final long timestamp, final GroupChat channel,
+    public ChannelSelfNickChangeEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser client, final String oldNick) {
         super(timestamp, channel);
         this.client = client;

--- a/src/com/dmdirc/events/ChannelSelfPartEvent.java
+++ b/src/com/dmdirc/events/ChannelSelfPartEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when the local user parts a channel.
  */
@@ -33,7 +35,7 @@ public class ChannelSelfPartEvent extends ChannelDisplayableEvent {
     private final GroupChatUser client;
     private final String message;
 
-    public ChannelSelfPartEvent(final long timestamp, final GroupChat channel,
+    public ChannelSelfPartEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser client, final String message) {
         super(timestamp, channel);
         this.client = client;

--- a/src/com/dmdirc/events/ChannelTopicChangeEvent.java
+++ b/src/com/dmdirc/events/ChannelTopicChangeEvent.java
@@ -26,6 +26,8 @@ import com.dmdirc.Topic;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a topic is changed.
  */
@@ -34,7 +36,7 @@ public class ChannelTopicChangeEvent extends ChannelDisplayableEvent {
     private final Topic topic;
     private final GroupChatUser user;
 
-    public ChannelTopicChangeEvent(final long timestamp, final GroupChat channel,
+    public ChannelTopicChangeEvent(final LocalDateTime timestamp, final GroupChat channel,
             final Topic topic, final GroupChatUser user) {
         super(timestamp, channel);
         this.topic = topic;

--- a/src/com/dmdirc/events/ChannelTopicUnsetEvent.java
+++ b/src/com/dmdirc/events/ChannelTopicUnsetEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a topic is cleared.
  */
@@ -32,7 +34,7 @@ public class ChannelTopicUnsetEvent extends ChannelDisplayableEvent {
 
     private final GroupChatUser client;
 
-    public ChannelTopicUnsetEvent(final long timestamp, final GroupChat channel,
+    public ChannelTopicUnsetEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser client) {
         super(timestamp, channel);
         this.client = client;

--- a/src/com/dmdirc/events/ChannelUserAwayEvent.java
+++ b/src/com/dmdirc/events/ChannelUserAwayEvent.java
@@ -25,6 +25,7 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 /**
@@ -34,7 +35,7 @@ public class ChannelUserAwayEvent extends ChannelUserEvent {
 
     private final Optional<String> reason;
 
-    public ChannelUserAwayEvent(final long timestamp, final GroupChat channel,
+    public ChannelUserAwayEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser user) {
         super(timestamp, channel, user);
         reason = Optional.empty();
@@ -45,7 +46,7 @@ public class ChannelUserAwayEvent extends ChannelUserEvent {
         reason = Optional.empty();
     }
 
-    public ChannelUserAwayEvent(final long timestamp, final GroupChat channel,
+    public ChannelUserAwayEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser user, final Optional<String> reason) {
         super(timestamp, channel, user);
         this.reason = reason;

--- a/src/com/dmdirc/events/ChannelUserBackEvent.java
+++ b/src/com/dmdirc/events/ChannelUserBackEvent.java
@@ -25,12 +25,14 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a user sets back.
  */
 public class ChannelUserBackEvent extends ChannelUserEvent {
 
-    public ChannelUserBackEvent(final long timestamp, final GroupChat channel,
+    public ChannelUserBackEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser user) {
         super(timestamp, channel, user);
     }

--- a/src/com/dmdirc/events/ChannelUserEvent.java
+++ b/src/com/dmdirc/events/ChannelUserEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Base type for events that occur in channels against users.
  */
@@ -32,7 +34,7 @@ public abstract class ChannelUserEvent extends ChannelDisplayableEvent {
 
     private final GroupChatUser user;
 
-    public ChannelUserEvent(final long timestamp, final GroupChat channel,
+    public ChannelUserEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser user) {
         super(timestamp, channel);
         this.user = user;

--- a/src/com/dmdirc/events/ChannelUserModeChangeEvent.java
+++ b/src/com/dmdirc/events/ChannelUserModeChangeEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a channel user mode change occurs.
  */
@@ -34,7 +36,7 @@ public class ChannelUserModeChangeEvent extends ChannelDisplayableEvent {
     private final GroupChatUser victim;
     private final String modes;
 
-    public ChannelUserModeChangeEvent(final long timestamp, final GroupChat channel,
+    public ChannelUserModeChangeEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser user, final GroupChatUser victim, final String modes) {
         super(timestamp, channel);
         this.user = user;

--- a/src/com/dmdirc/events/CommandOutputEvent.java
+++ b/src/com/dmdirc/events/CommandOutputEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.WindowModel;
 
+import java.time.LocalDateTime;
+
 /**
  * Event raised when a command outputs some generic text to the user.
  */
@@ -31,7 +33,7 @@ public class CommandOutputEvent extends BaseDisplayableEvent {
 
     private final String message;
 
-    public CommandOutputEvent(final WindowModel source, final long timestamp,
+    public CommandOutputEvent(final LocalDateTime timestamp, final WindowModel source,
             final String message) {
         super(timestamp, source);
         this.message = message;

--- a/src/com/dmdirc/events/DMDircEvent.java
+++ b/src/com/dmdirc/events/DMDircEvent.java
@@ -22,33 +22,35 @@
 
 package com.dmdirc.events;
 
+import java.time.LocalDateTime;
+
 /**
  * Base class for all DMDirc events.
  */
 public abstract class DMDircEvent {
 
     /**
-     * The timestamp the event was triggered at, in milliseconds.
+     * The time the event was triggered at.
      */
-    private final long timestamp;
+    private final LocalDateTime timestamp;
 
     /**
      * Creates a new event with the specified timestamp.
      *
-     * @param timestamp The timestamp the event was triggered at, in milliseconds.
+     * @param timestamp The stamp the event was triggered at.
      */
-    public DMDircEvent(final long timestamp) {
+    protected DMDircEvent(final LocalDateTime timestamp) {
         this.timestamp = timestamp;
     }
 
     /**
      * Creates a new event with the current system timestamp.
      */
-    public DMDircEvent() {
-        this.timestamp = System.currentTimeMillis();
+    protected DMDircEvent() {
+        this.timestamp = LocalDateTime.now();
     }
 
-    public long getTimestamp() {
+    public LocalDateTime getTimestamp() {
         return timestamp;
     }
 

--- a/src/com/dmdirc/events/DisplayableEvent.java
+++ b/src/com/dmdirc/events/DisplayableEvent.java
@@ -24,6 +24,7 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.WindowModel;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 /**
@@ -71,11 +72,11 @@ public interface DisplayableEvent {
     DisplayPropertyMap getDisplayProperties();
 
     /**
-     * Gets the timestamp at which the event occurred.
+     * Gets the times at which the event occurred.
      *
-     * @return The timestamp the event occurred at.
+     * @return The time the event occurred at.
      */
-    long getTimestamp();
+    LocalDateTime getTimestamp();
 
     /**
      * Gets the source of the displayable event.

--- a/src/com/dmdirc/events/ErrorEvent.java
+++ b/src/com/dmdirc/events/ErrorEvent.java
@@ -37,7 +37,6 @@ public abstract class ErrorEvent extends DMDircEvent {
             final Throwable throwable,
             final String message,
             final String details) {
-        super(System.currentTimeMillis());
         this.level = level;
         this.message = message;
         this.throwable = throwable;

--- a/src/com/dmdirc/events/NickListClientAddedEvent.java
+++ b/src/com/dmdirc/events/NickListClientAddedEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a user is added to the list of users.
  */
@@ -32,7 +34,7 @@ public class NickListClientAddedEvent extends NickListEvent {
 
     private final GroupChatUser user;
 
-    public NickListClientAddedEvent(final long timestamp, final GroupChat channel,
+    public NickListClientAddedEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser user) {
         super(timestamp, channel);
         this.user = user;

--- a/src/com/dmdirc/events/NickListClientRemovedEvent.java
+++ b/src/com/dmdirc/events/NickListClientRemovedEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.GroupChat;
 import com.dmdirc.interfaces.GroupChatUser;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a user is removed from the list of users.
  */
@@ -32,7 +34,7 @@ public class NickListClientRemovedEvent extends NickListEvent {
 
     private final GroupChatUser user;
 
-    public NickListClientRemovedEvent(final long timestamp, final GroupChat channel,
+    public NickListClientRemovedEvent(final LocalDateTime timestamp, final GroupChat channel,
             final GroupChatUser user) {
         super(timestamp, channel);
         this.user = user;

--- a/src/com/dmdirc/events/NickListClientsChangedEvent.java
+++ b/src/com/dmdirc/events/NickListClientsChangedEvent.java
@@ -27,6 +27,7 @@ import com.dmdirc.interfaces.GroupChatUser;
 
 import com.google.common.collect.Lists;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -37,7 +38,7 @@ public class NickListClientsChangedEvent extends NickListEvent {
 
     private final Collection<GroupChatUser> users;
 
-    public NickListClientsChangedEvent(final long timestamp, final GroupChat channel,
+    public NickListClientsChangedEvent(final LocalDateTime timestamp, final GroupChat channel,
             final Iterable<GroupChatUser> users) {
         super(timestamp, channel);
         this.users = Lists.newArrayList(users);

--- a/src/com/dmdirc/events/NickListEvent.java
+++ b/src/com/dmdirc/events/NickListEvent.java
@@ -2,12 +2,14 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.GroupChat;
 
+import java.time.LocalDateTime;
+
 /**
  * Base class for all nicklist events in a {@link GroupChat}.
  */
 public abstract class NickListEvent extends ChannelEvent {
 
-    public NickListEvent(final long timestamp, final GroupChat channel) {
+    public NickListEvent(final LocalDateTime timestamp, final GroupChat channel) {
         super(timestamp, channel);
     }
 

--- a/src/com/dmdirc/events/NickListUpdatedEvent.java
+++ b/src/com/dmdirc/events/NickListUpdatedEvent.java
@@ -24,12 +24,14 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.GroupChat;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when the properties of the users in a list changes.
  */
 public class NickListUpdatedEvent extends NickListEvent {
 
-    public NickListUpdatedEvent(final long timestamp, final GroupChat channel) {
+    public NickListUpdatedEvent(final LocalDateTime timestamp, final GroupChat channel) {
         super(timestamp, channel);
     }
 

--- a/src/com/dmdirc/events/QueryActionEvent.java
+++ b/src/com/dmdirc/events/QueryActionEvent.java
@@ -25,12 +25,14 @@ package com.dmdirc.events;
 import com.dmdirc.Query;
 import com.dmdirc.interfaces.User;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when an action occurs in a query.
  */
 public class QueryActionEvent extends BaseQueryActionEvent {
 
-    public QueryActionEvent(final long timestamp, final Query query, final User user,
+    public QueryActionEvent(final LocalDateTime timestamp, final Query query, final User user,
             final String message) {
         super(timestamp, query, user, message);
     }

--- a/src/com/dmdirc/events/QueryClosedEvent.java
+++ b/src/com/dmdirc/events/QueryClosedEvent.java
@@ -24,12 +24,14 @@ package com.dmdirc.events;
 
 import com.dmdirc.Query;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a query window is closed.
  */
 public class QueryClosedEvent extends QueryEvent {
 
-    public QueryClosedEvent(final long timestamp, final Query query) {
+    public QueryClosedEvent(final LocalDateTime timestamp, final Query query) {
         super(timestamp, query);
     }
 

--- a/src/com/dmdirc/events/QueryDisplayableEvent.java
+++ b/src/com/dmdirc/events/QueryDisplayableEvent.java
@@ -25,6 +25,7 @@ package com.dmdirc.events;
 import com.dmdirc.Query;
 import com.dmdirc.interfaces.WindowModel;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 /**
@@ -35,7 +36,7 @@ public abstract class QueryDisplayableEvent extends QueryEvent implements Displa
     /** The properties associated with this event. */
     private final DisplayPropertyMap properties = new DisplayPropertyMap();
 
-    public QueryDisplayableEvent(final long timestamp, final Query query) {
+    public QueryDisplayableEvent(final LocalDateTime timestamp, final Query query) {
         super(timestamp, query);
     }
 

--- a/src/com/dmdirc/events/QueryEvent.java
+++ b/src/com/dmdirc/events/QueryEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.Query;
 
+import java.time.LocalDateTime;
+
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -34,7 +36,7 @@ public abstract class QueryEvent extends DMDircEvent {
     /** The query that this event occurred on. */
     private final Query query;
 
-    public QueryEvent(final long timestamp, final Query query) {
+    public QueryEvent(final LocalDateTime timestamp, final Query query) {
         super(timestamp);
         this.query = checkNotNull(query);
     }

--- a/src/com/dmdirc/events/QueryMessageEvent.java
+++ b/src/com/dmdirc/events/QueryMessageEvent.java
@@ -25,12 +25,14 @@ package com.dmdirc.events;
 import com.dmdirc.Query;
 import com.dmdirc.interfaces.User;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a message occurs in a query.
  */
 public class QueryMessageEvent extends BaseQueryMessageEvent {
 
-    public QueryMessageEvent(final long timestamp, final Query query, final User user,
+    public QueryMessageEvent(final LocalDateTime timestamp, final Query query, final User user,
             final String message) {
         super(timestamp, query, user, message);
     }

--- a/src/com/dmdirc/events/QueryNickChangeEvent.java
+++ b/src/com/dmdirc/events/QueryNickChangeEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.Query;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a user changes nickname in a query.
  */
@@ -32,8 +34,8 @@ public class QueryNickChangeEvent extends QueryDisplayableEvent {
     private final String oldNick;
     private final String newNick;
 
-    public QueryNickChangeEvent(final long timestamp, final Query query, final String oldNick,
-            final String newNick) {
+    public QueryNickChangeEvent(final LocalDateTime timestamp, final Query query,
+            final String oldNick, final String newNick) {
         super(timestamp, query);
         this.oldNick = oldNick;
         this.newNick = newNick;

--- a/src/com/dmdirc/events/QueryOpenedEvent.java
+++ b/src/com/dmdirc/events/QueryOpenedEvent.java
@@ -24,12 +24,14 @@ package com.dmdirc.events;
 
 import com.dmdirc.Query;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a query window is opened.
  */
 public class QueryOpenedEvent extends QueryEvent {
 
-    public QueryOpenedEvent(final long timestamp, final Query query) {
+    public QueryOpenedEvent(final LocalDateTime timestamp, final Query query) {
         super(timestamp, query);
     }
 

--- a/src/com/dmdirc/events/QueryQuitEvent.java
+++ b/src/com/dmdirc/events/QueryQuitEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.Query;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a user quits when a query is open.
  */
@@ -31,7 +33,7 @@ public class QueryQuitEvent extends QueryDisplayableEvent {
 
     private final String reason;
 
-    public QueryQuitEvent(final long timestamp, final Query query, final String reason) {
+    public QueryQuitEvent(final LocalDateTime timestamp, final Query query, final String reason) {
         super(timestamp, query);
         this.reason = reason;
     }

--- a/src/com/dmdirc/events/QuerySelfActionEvent.java
+++ b/src/com/dmdirc/events/QuerySelfActionEvent.java
@@ -25,12 +25,14 @@ package com.dmdirc.events;
 import com.dmdirc.Query;
 import com.dmdirc.interfaces.User;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a self action is sent in query.
  */
 public class QuerySelfActionEvent extends BaseQueryActionEvent {
 
-    public QuerySelfActionEvent(final long timestamp, final Query query, final User user,
+    public QuerySelfActionEvent(final LocalDateTime timestamp, final Query query, final User user,
             final String message) {
         super(timestamp, query, user, message);
     }

--- a/src/com/dmdirc/events/QuerySelfMessageEvent.java
+++ b/src/com/dmdirc/events/QuerySelfMessageEvent.java
@@ -25,12 +25,14 @@ package com.dmdirc.events;
 import com.dmdirc.Query;
 import com.dmdirc.interfaces.User;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a self message happens in a query.
  */
 public class QuerySelfMessageEvent extends BaseQueryMessageEvent {
 
-    public QuerySelfMessageEvent(final long timestamp, final Query query, final User user,
+    public QuerySelfMessageEvent(final LocalDateTime timestamp, final Query query, final User user,
             final String message) {
         super(timestamp, query, user, message);
     }

--- a/src/com/dmdirc/events/ServerAuthNoticeEvent.java
+++ b/src/com/dmdirc/events/ServerAuthNoticeEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.Connection;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired on receiving an auth notice.
  */
@@ -31,7 +33,7 @@ public class ServerAuthNoticeEvent extends ServerDisplayableEvent {
 
     private final String notice;
 
-    public ServerAuthNoticeEvent(final long timestamp, final Connection connection,
+    public ServerAuthNoticeEvent(final LocalDateTime timestamp, final Connection connection,
             final String notice) {
         super(timestamp, connection);
         this.notice = notice;

--- a/src/com/dmdirc/events/ServerAwayEvent.java
+++ b/src/com/dmdirc/events/ServerAwayEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.Connection;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when you set away.
  */
@@ -31,7 +33,8 @@ public class ServerAwayEvent extends ServerDisplayableEvent {
 
     private final String reason;
 
-    public ServerAwayEvent(final long timestamp, final Connection connection, final String reason) {
+    public ServerAwayEvent(final LocalDateTime timestamp, final Connection connection,
+            final String reason) {
         super(timestamp, connection);
         this.reason = reason;
     }

--- a/src/com/dmdirc/events/ServerBackEvent.java
+++ b/src/com/dmdirc/events/ServerBackEvent.java
@@ -24,12 +24,14 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.Connection;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when you set back from being away.
  */
 public class ServerBackEvent extends ServerDisplayableEvent {
 
-    public ServerBackEvent(final long timestamp, final Connection connection) {
+    public ServerBackEvent(final LocalDateTime timestamp, final Connection connection) {
         super(timestamp, connection);
     }
 

--- a/src/com/dmdirc/events/ServerConnectErrorEvent.java
+++ b/src/com/dmdirc/events/ServerConnectErrorEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.Connection;
 
+import java.time.LocalDateTime;
+
 /**
  * Fire when a server errored whilst connecting.
  */
@@ -36,7 +38,7 @@ public class ServerConnectErrorEvent extends ServerEvent {
         this.message = message;
     }
 
-    public ServerConnectErrorEvent(final long timestamp, final Connection connection,
+    public ServerConnectErrorEvent(final LocalDateTime timestamp, final Connection connection,
             final String message) {
         super(timestamp, connection);
         this.message = message;

--- a/src/com/dmdirc/events/ServerConnectedEvent.java
+++ b/src/com/dmdirc/events/ServerConnectedEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.Connection;
 
+import java.time.LocalDateTime;
+
 /**
  * Fire when a server is connected.
  */
@@ -33,7 +35,7 @@ public class ServerConnectedEvent extends ServerEvent {
         super(connection);
     }
 
-    public ServerConnectedEvent(final long timestamp, final Connection connection) {
+    public ServerConnectedEvent(final LocalDateTime timestamp, final Connection connection) {
         super(timestamp, connection);
     }
 

--- a/src/com/dmdirc/events/ServerConnectingEvent.java
+++ b/src/com/dmdirc/events/ServerConnectingEvent.java
@@ -25,6 +25,7 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.Connection;
 
 import java.net.URI;
+import java.time.LocalDateTime;
 
 /**
  * Fire when a server is connecting.
@@ -38,7 +39,7 @@ public class ServerConnectingEvent extends ServerDisplayableEvent {
         this.uri = uri;
     }
 
-    public ServerConnectingEvent(final long timestamp, final Connection connection, final URI uri) {
+    public ServerConnectingEvent(final LocalDateTime timestamp, final Connection connection, final URI uri) {
         super(timestamp, connection);
         this.uri = uri;
     }

--- a/src/com/dmdirc/events/ServerCtcpEvent.java
+++ b/src/com/dmdirc/events/ServerCtcpEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.Connection;
 import com.dmdirc.interfaces.User;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when receiving a CTCP event.
  */
@@ -35,7 +37,7 @@ public class ServerCtcpEvent extends ServerDisplayableEvent {
     private final String content;
     private boolean handled;
 
-    public ServerCtcpEvent(final long timestamp, final Connection connection,
+    public ServerCtcpEvent(final LocalDateTime timestamp, final Connection connection,
             final User user, final String type, final String content) {
         super(timestamp, connection);
         this.user = user;

--- a/src/com/dmdirc/events/ServerCtcpReplyEvent.java
+++ b/src/com/dmdirc/events/ServerCtcpReplyEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.Connection;
 import com.dmdirc.interfaces.User;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when sending a CTCP reply.
  */
@@ -34,8 +36,8 @@ public class ServerCtcpReplyEvent extends ServerDisplayableEvent {
     private final String type;
     private final String content;
 
-    public ServerCtcpReplyEvent(final long timestamp, final Connection connection, final User user,
-            final String type, final String content) {
+    public ServerCtcpReplyEvent(final LocalDateTime timestamp, final Connection connection,
+            final User user, final String type, final String content) {
         super(timestamp, connection);
         this.user = user;
         this.type = type;

--- a/src/com/dmdirc/events/ServerCtcpSentEvent.java
+++ b/src/com/dmdirc/events/ServerCtcpSentEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.Connection;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a CTCP is manually sent from the local client.
  */
@@ -32,7 +34,7 @@ public class ServerCtcpSentEvent extends ServerDisplayableEvent {
     private final String target;
     private final String data;
 
-    public ServerCtcpSentEvent(final long timestamp, final Connection connection,
+    public ServerCtcpSentEvent(final LocalDateTime timestamp, final Connection connection,
             final String target, final String data) {
         super(timestamp, connection);
         this.target = target;

--- a/src/com/dmdirc/events/ServerDisconnectedEvent.java
+++ b/src/com/dmdirc/events/ServerDisconnectedEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.Connection;
 
+import java.time.LocalDateTime;
+
 /**
  * Fire when a server disconnects.
  */
@@ -33,7 +35,7 @@ public class ServerDisconnectedEvent extends ServerDisplayableEvent {
         super(connection);
     }
 
-    public ServerDisconnectedEvent(final long timestamp, final Connection connection) {
+    public ServerDisconnectedEvent(final LocalDateTime timestamp, final Connection connection) {
         super(timestamp, connection);
     }
 

--- a/src/com/dmdirc/events/ServerDisplayableEvent.java
+++ b/src/com/dmdirc/events/ServerDisplayableEvent.java
@@ -25,6 +25,7 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.Connection;
 import com.dmdirc.interfaces.WindowModel;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 
@@ -36,7 +37,7 @@ public abstract class ServerDisplayableEvent extends ServerEvent implements Disp
     /** The properties associated with this event. */
     private final DisplayPropertyMap properties = new DisplayPropertyMap();
 
-    public ServerDisplayableEvent(final long timestamp, final Connection connection) {
+    public ServerDisplayableEvent(final LocalDateTime timestamp, final Connection connection) {
         super(timestamp, connection);
     }
 

--- a/src/com/dmdirc/events/ServerErrorEvent.java
+++ b/src/com/dmdirc/events/ServerErrorEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.Connection;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired on receipt of a server error.
  */
@@ -31,7 +33,8 @@ public class ServerErrorEvent extends ServerDisplayableEvent {
 
     private final String reason;
 
-    public ServerErrorEvent(final long timestamp, final Connection connection, final String reason) {
+    public ServerErrorEvent(final LocalDateTime timestamp, final Connection connection,
+            final String reason) {
         super(timestamp, connection);
         this.reason = reason;
     }

--- a/src/com/dmdirc/events/ServerEvent.java
+++ b/src/com/dmdirc/events/ServerEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.Connection;
 
+import java.time.LocalDateTime;
+
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -34,7 +36,7 @@ public abstract class ServerEvent extends DMDircEvent {
     /** The connection that this event occurred on. */
     private final Connection connection;
 
-    public ServerEvent(final long timestamp, final Connection connection) {
+    public ServerEvent(final LocalDateTime timestamp, final Connection connection) {
         super(timestamp);
         this.connection = checkNotNull(connection);
     }

--- a/src/com/dmdirc/events/ServerGotPingEvent.java
+++ b/src/com/dmdirc/events/ServerGotPingEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.Connection;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when we receive a server ping reply.
  */
@@ -31,7 +33,8 @@ public class ServerGotPingEvent extends ServerEvent {
 
     private final long ping;
 
-    public ServerGotPingEvent(final long timestamp, final Connection connection, final long ping) {
+    public ServerGotPingEvent(final LocalDateTime timestamp, final Connection connection,
+            final long ping) {
         super(timestamp, connection);
         this.ping = ping;
     }

--- a/src/com/dmdirc/events/ServerInviteExpiredEvent.java
+++ b/src/com/dmdirc/events/ServerInviteExpiredEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.Invite;
 import com.dmdirc.interfaces.Connection;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when an @link Invite} is expired.
  */
@@ -37,7 +39,7 @@ public class ServerInviteExpiredEvent extends ServerEvent {
         this.invite = invite;
     }
 
-    public ServerInviteExpiredEvent(final long timestamp, final Connection connection,
+    public ServerInviteExpiredEvent(final LocalDateTime timestamp, final Connection connection,
             final Invite invite) {
         super(timestamp, connection);
         this.invite = invite;

--- a/src/com/dmdirc/events/ServerInviteReceivedEvent.java
+++ b/src/com/dmdirc/events/ServerInviteReceivedEvent.java
@@ -26,6 +26,8 @@ import com.dmdirc.Invite;
 import com.dmdirc.interfaces.Connection;
 import com.dmdirc.interfaces.User;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when an invite is received.
  */
@@ -35,7 +37,7 @@ public class ServerInviteReceivedEvent extends ServerDisplayableEvent {
     private final String channel;
     private final Invite invite;
 
-    public ServerInviteReceivedEvent(final long timestamp, final Connection connection,
+    public ServerInviteReceivedEvent(final LocalDateTime timestamp, final Connection connection,
             final User user, final String channel, final Invite invite) {
         super(timestamp, connection);
         this.user = user;

--- a/src/com/dmdirc/events/ServerMessageSentEvent.java
+++ b/src/com/dmdirc/events/ServerMessageSentEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.Connection;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a message is manually sent from the local client.
  */
@@ -32,7 +34,7 @@ public class ServerMessageSentEvent extends ServerDisplayableEvent {
     private final String target;
     private final String message;
 
-    public ServerMessageSentEvent(final long timestamp, final Connection connection,
+    public ServerMessageSentEvent(final LocalDateTime timestamp, final Connection connection,
             final String target, final String message) {
         super(timestamp, connection);
         this.target = target;

--- a/src/com/dmdirc/events/ServerMotdEndEvent.java
+++ b/src/com/dmdirc/events/ServerMotdEndEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.Connection;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when the MOTD ends.
  */
@@ -31,7 +33,7 @@ public class ServerMotdEndEvent extends ServerDisplayableEvent {
 
     private final String message;
 
-    public ServerMotdEndEvent(final long timestamp, final Connection connection,
+    public ServerMotdEndEvent(final LocalDateTime timestamp, final Connection connection,
             final String message) {
         super(timestamp, connection);
         this.message = message;

--- a/src/com/dmdirc/events/ServerMotdLineEvent.java
+++ b/src/com/dmdirc/events/ServerMotdLineEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.Connection;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when the MOTD line is received.
  */
@@ -31,7 +33,7 @@ public class ServerMotdLineEvent extends ServerDisplayableEvent {
 
     private final String message;
 
-    public ServerMotdLineEvent(final long timestamp, final Connection connection,
+    public ServerMotdLineEvent(final LocalDateTime timestamp, final Connection connection,
             final String message) {
         super(timestamp, connection);
         this.message = message;

--- a/src/com/dmdirc/events/ServerMotdStartEvent.java
+++ b/src/com/dmdirc/events/ServerMotdStartEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.Connection;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when the MOTD starts.
  */
@@ -31,7 +33,7 @@ public class ServerMotdStartEvent extends ServerDisplayableEvent {
 
     private final String message;
 
-    public ServerMotdStartEvent(final long timestamp, final Connection connection,
+    public ServerMotdStartEvent(final LocalDateTime timestamp, final Connection connection,
             final String message) {
         super(timestamp, connection);
         this.message = message;

--- a/src/com/dmdirc/events/ServerNickChangeEvent.java
+++ b/src/com/dmdirc/events/ServerNickChangeEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.Connection;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired on a change of a nickname.
  */
@@ -32,7 +34,7 @@ public class ServerNickChangeEvent extends ServerDisplayableEvent {
     private final String oldNick;
     private final String newNick;
 
-    public ServerNickChangeEvent(final long timestamp, final Connection connection,
+    public ServerNickChangeEvent(final LocalDateTime timestamp, final Connection connection,
             final String oldNick, final String newNick) {
         super(timestamp, connection);
         this.oldNick = oldNick;

--- a/src/com/dmdirc/events/ServerNoPingEvent.java
+++ b/src/com/dmdirc/events/ServerNoPingEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.Connection;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when we miss a server ping reply.
  */
@@ -31,7 +33,8 @@ public class ServerNoPingEvent extends ServerEvent {
 
     private final long ping;
 
-    public ServerNoPingEvent(final long timestamp, final Connection connection, final long ping) {
+    public ServerNoPingEvent(final LocalDateTime timestamp, final Connection connection,
+            final long ping) {
         super(timestamp, connection);
         this.ping = ping;
     }

--- a/src/com/dmdirc/events/ServerNoticeEvent.java
+++ b/src/com/dmdirc/events/ServerNoticeEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.Connection;
 import com.dmdirc.interfaces.User;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when receiving a notice.
  */
@@ -33,7 +35,7 @@ public class ServerNoticeEvent extends ServerDisplayableEvent {
     private final User user;
     private final String message;
 
-    public ServerNoticeEvent(final long timestamp, final Connection connection,
+    public ServerNoticeEvent(final LocalDateTime timestamp, final Connection connection,
             final User user, final String message) {
         super(timestamp, connection);
         this.user = user;

--- a/src/com/dmdirc/events/ServerNoticeSentEvent.java
+++ b/src/com/dmdirc/events/ServerNoticeSentEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.Connection;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a notice is manually sent from the local client.
  */
@@ -32,7 +34,7 @@ public class ServerNoticeSentEvent extends ServerDisplayableEvent {
     private final String target;
     private final String message;
 
-    public ServerNoticeSentEvent(final long timestamp, final Connection connection,
+    public ServerNoticeSentEvent(final LocalDateTime timestamp, final Connection connection,
             final String target, final String message) {
         super(timestamp, connection);
         this.target = target;

--- a/src/com/dmdirc/events/ServerNumericEvent.java
+++ b/src/com/dmdirc/events/ServerNumericEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.Connection;
 
+import java.time.LocalDateTime;
+
 /**
  * Event raised when a server numeric occurs.
  */
@@ -32,8 +34,8 @@ public class ServerNumericEvent extends ServerDisplayableEvent {
     private final int numeric;
     private final String[] args;
 
-    public ServerNumericEvent(final long timestamp, final Connection server, final int numeric,
-            final String[] args) {
+    public ServerNumericEvent(final LocalDateTime timestamp, final Connection server,
+            final int numeric, final String[] args) {
         super(timestamp, server);
         this.numeric = numeric;
         this.args = args;

--- a/src/com/dmdirc/events/ServerPingSentEvent.java
+++ b/src/com/dmdirc/events/ServerPingSentEvent.java
@@ -24,12 +24,14 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.Connection;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when sending a server ping request.
  */
 public class ServerPingSentEvent extends ServerEvent {
 
-    public ServerPingSentEvent(final long timestamp, final Connection connection) {
+    public ServerPingSentEvent(final LocalDateTime timestamp, final Connection connection) {
         super(timestamp, connection);
     }
 

--- a/src/com/dmdirc/events/ServerRawLineSentEvent.java
+++ b/src/com/dmdirc/events/ServerRawLineSentEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.Connection;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when a raw line is manually sent from the local client.
  */
@@ -31,7 +33,7 @@ public class ServerRawLineSentEvent extends ServerDisplayableEvent {
 
     private final String line;
 
-    public ServerRawLineSentEvent(final long timestamp, final Connection connection,
+    public ServerRawLineSentEvent(final LocalDateTime timestamp, final Connection connection,
             final String line) {
         super(timestamp, connection);
         this.line = line;

--- a/src/com/dmdirc/events/ServerServerNoticeEvent.java
+++ b/src/com/dmdirc/events/ServerServerNoticeEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.Connection;
 import com.dmdirc.interfaces.User;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when receiving a server notice.
  */
@@ -33,7 +35,7 @@ public class ServerServerNoticeEvent extends ServerDisplayableEvent {
     private final User user;
     private final String message;
 
-    public ServerServerNoticeEvent(final long timestamp, final Connection connection,
+    public ServerServerNoticeEvent(final LocalDateTime timestamp, final Connection connection,
             final User user, final String message) {
         super(timestamp, connection);
         this.user = user;

--- a/src/com/dmdirc/events/ServerUnknownActionEvent.java
+++ b/src/com/dmdirc/events/ServerUnknownActionEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.Connection;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when an unknown action is received.
  */
@@ -33,7 +35,7 @@ public class ServerUnknownActionEvent extends ServerDisplayableEvent {
     private final String target;
     private final String message;
 
-    public ServerUnknownActionEvent(final long timestamp, final Connection connection,
+    public ServerUnknownActionEvent(final LocalDateTime timestamp, final Connection connection,
             final String sender, final String target, final String message) {
         super(timestamp, connection);
         this.sender = sender;

--- a/src/com/dmdirc/events/ServerUnknownMessageEvent.java
+++ b/src/com/dmdirc/events/ServerUnknownMessageEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.Connection;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when an unknown message is received.
  */
@@ -33,7 +35,7 @@ public class ServerUnknownMessageEvent extends ServerDisplayableEvent {
     private final String target;
     private final String message;
 
-    public ServerUnknownMessageEvent(final long timestamp, final Connection connection,
+    public ServerUnknownMessageEvent(final LocalDateTime timestamp, final Connection connection,
             final String sender, final String target, final String message) {
         super(timestamp, connection);
         this.sender = sender;

--- a/src/com/dmdirc/events/ServerUnknownNoticeEvent.java
+++ b/src/com/dmdirc/events/ServerUnknownNoticeEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.Connection;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when an unknown notice is received.
  */
@@ -33,7 +35,7 @@ public class ServerUnknownNoticeEvent extends ServerDisplayableEvent {
     private final String target;
     private final String message;
 
-    public ServerUnknownNoticeEvent(final long timestamp, final Connection connection,
+    public ServerUnknownNoticeEvent(final LocalDateTime timestamp, final Connection connection,
             final String sender, final String target, final String message) {
         super(timestamp, connection);
         this.sender = sender;

--- a/src/com/dmdirc/events/ServerUnknownProtocolEvent.java
+++ b/src/com/dmdirc/events/ServerUnknownProtocolEvent.java
@@ -24,6 +24,8 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.Connection;
 
+import java.time.LocalDateTime;
+
 /**
  * Raised when a server attempts to connect to an unknown protocol.
  */
@@ -31,7 +33,8 @@ public class ServerUnknownProtocolEvent extends ServerDisplayableEvent {
 
     private final String protocol;
 
-    public ServerUnknownProtocolEvent(final long timestamp, final Connection connection, final String protocol) {
+    public ServerUnknownProtocolEvent(final LocalDateTime timestamp, final Connection connection,
+            final String protocol) {
         super(timestamp, connection);
         this.protocol = protocol;
     }

--- a/src/com/dmdirc/events/ServerUserModesEvent.java
+++ b/src/com/dmdirc/events/ServerUserModesEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.Connection;
 import com.dmdirc.interfaces.User;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired in on receipt of user modes.
  */
@@ -33,8 +35,8 @@ public class ServerUserModesEvent extends ServerDisplayableEvent {
     private final User user;
     private final String modes;
 
-    public ServerUserModesEvent(final long timestamp, final Connection connection, final User user,
-            final String modes) {
+    public ServerUserModesEvent(final LocalDateTime timestamp, final Connection connection,
+            final User user, final String modes) {
         super(timestamp, connection);
         this.user = user;
         this.modes = modes;

--- a/src/com/dmdirc/events/ServerWalldesyncEvent.java
+++ b/src/com/dmdirc/events/ServerWalldesyncEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.Connection;
 import com.dmdirc.interfaces.User;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when receiving a server walldesync.
  */
@@ -33,8 +35,8 @@ public class ServerWalldesyncEvent extends ServerDisplayableEvent {
     private final User user;
     private final String message;
 
-    public ServerWalldesyncEvent(final long timestamp, final Connection connection, final User user,
-            final String message) {
+    public ServerWalldesyncEvent(final LocalDateTime timestamp, final Connection connection,
+            final User user, final String message) {
         super(timestamp, connection);
         this.user = user;
         this.message = message;

--- a/src/com/dmdirc/events/ServerWallopsEvent.java
+++ b/src/com/dmdirc/events/ServerWallopsEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.Connection;
 import com.dmdirc.interfaces.User;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when receiving a server wallops.
  */
@@ -33,7 +35,7 @@ public class ServerWallopsEvent extends ServerDisplayableEvent {
     private final User user;
     private final String message;
 
-    public ServerWallopsEvent(final long timestamp, final Connection connection,
+    public ServerWallopsEvent(final LocalDateTime timestamp, final Connection connection,
             final User user, final String message) {
         super(timestamp, connection);
         this.user = user;

--- a/src/com/dmdirc/events/ServerWallusersEvent.java
+++ b/src/com/dmdirc/events/ServerWallusersEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.Connection;
 import com.dmdirc.interfaces.User;
 
+import java.time.LocalDateTime;
+
 /**
  * Fired when receiving a server wallusers.
  */
@@ -33,7 +35,7 @@ public class ServerWallusersEvent extends ServerDisplayableEvent {
     private final User user;
     private final String message;
 
-    public ServerWallusersEvent(final long timestamp, final Connection connection,
+    public ServerWallusersEvent(final LocalDateTime timestamp, final Connection connection,
             final User user, final String message) {
         super(timestamp, connection);
         this.user = user;

--- a/src/com/dmdirc/events/UnknownCommandEvent.java
+++ b/src/com/dmdirc/events/UnknownCommandEvent.java
@@ -24,6 +24,7 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.WindowModel;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import javax.annotation.Nullable;
@@ -39,7 +40,7 @@ public class UnknownCommandEvent extends DMDircEvent implements DisplayableEvent
     private final String command;
     private final String[] arguments;
 
-    public UnknownCommandEvent(final long timestamp, @Nullable final WindowModel source,
+    public UnknownCommandEvent(final LocalDateTime timestamp, @Nullable final WindowModel source,
             final String command, final String[] arguments) {
         super(timestamp);
         this.source = source;

--- a/src/com/dmdirc/events/UserInfoResponseEvent.java
+++ b/src/com/dmdirc/events/UserInfoResponseEvent.java
@@ -25,7 +25,9 @@ package com.dmdirc.events;
 import com.dmdirc.interfaces.Connection;
 import com.dmdirc.interfaces.User;
 import com.dmdirc.parser.events.UserInfoEvent;
+import com.dmdirc.parser.events.UserInfoEvent.UserInfoType;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.Map;
@@ -37,13 +39,13 @@ import java.util.Optional;
 public class UserInfoResponseEvent extends ServerDisplayableEvent {
 
     private final User user;
-    private final Map<UserInfoEvent.UserInfoType, UserInfoProperty> info;
+    private final Map<UserInfoType, UserInfoProperty> info;
 
-    public UserInfoResponseEvent(final Connection connection, final long date,
-            final User user, final Map<UserInfoEvent.UserInfoType, String> info) {
+    public UserInfoResponseEvent(final LocalDateTime date, final Connection connection,
+            final User user, final Map<UserInfoType, String> info) {
         super(date, connection);
         this.user = user;
-        this.info = new EnumMap<>(UserInfoEvent.UserInfoType.class);
+        this.info = new EnumMap<>(UserInfoType.class);
         info.forEach((key, value) -> this.info.put(key, new UserInfoProperty(key, value)));
     }
 

--- a/src/com/dmdirc/logger/DiskLoggingErrorManager.java
+++ b/src/com/dmdirc/logger/DiskLoggingErrorManager.java
@@ -38,7 +38,6 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -103,7 +102,7 @@ public class DiskLoggingErrorManager {
         final String logName = error.getTimestamp() + "-" + error.getError().getLevel();
         final Path errorFile = errorsDirectory.resolve(logName + ".log");
         final List<String> data = Lists
-                .newArrayList("Date: " + new Date(error.getTimestamp()),
+                .newArrayList("Date: " + error.getTimestamp(),
                         "Level: " + error.getError().getLevel(),
                         "Description: " + error.getError().getMessage(),
                         "Details: ");

--- a/src/com/dmdirc/ui/messages/IRCDocument.java
+++ b/src/com/dmdirc/ui/messages/IRCDocument.java
@@ -29,8 +29,8 @@ import com.dmdirc.util.collections.ListenerList;
 
 import java.awt.Font;
 import java.io.Serializable;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import javax.swing.UIManager;
@@ -104,7 +104,7 @@ public class IRCDocument implements Serializable, ConfigChangeListener {
      * @param displayPropertyMap The display properties to use
      * @param text stylised string to add to the document
      */
-    public void addText(final long timestamp, final DisplayPropertyMap displayPropertyMap,
+    public void addText(final LocalDateTime timestamp, final DisplayPropertyMap displayPropertyMap,
             final String text) {
         final int start;
         synchronized (lines) {
@@ -115,8 +115,8 @@ public class IRCDocument implements Serializable, ConfigChangeListener {
         fireLinesAdded(start, 1);
     }
 
-    private String formatTimestamp(final long timestamp) {
-        return Formatter.formatMessage(configManager, "timestamp", new Date(timestamp));
+    private String formatTimestamp(final LocalDateTime timestamp) {
+        return Formatter.formatMessage(configManager, "timestamp", timestamp);
     }
 
     /**

--- a/test/com/dmdirc/logger/DiskLoggingErrorManagerTest.java
+++ b/test/com/dmdirc/logger/DiskLoggingErrorManagerTest.java
@@ -30,7 +30,7 @@ import com.dmdirc.tests.JimFsRule;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.junit.Before;
@@ -60,7 +60,7 @@ public class DiskLoggingErrorManagerTest {
 
     @Before
     public void setUp() throws Exception {
-        when(error.getTimestamp()).thenReturn(new Date().getTime());
+        when(error.getTimestamp()).thenReturn(LocalDateTime.now());
         when(error.getError()).thenReturn(programError);
         when(programError.getThrowable()).thenReturn(Optional.of(new IllegalArgumentException()));
         when(programError.getThrowableAsString()).thenReturn(Optional.of("test"));


### PR DESCRIPTION
Java 8 introduces a sane API for dates; to store datettimes
we should now be using LocalDateTime.