### PR TITLE
Add a base class for events with a WindowModel source.

### DIFF
--- a/src/com/dmdirc/Server.java
+++ b/src/com/dmdirc/Server.java
@@ -705,7 +705,7 @@ public class Server implements Connection {
 
     @Handler
     private void handleClose(final FrameClosingEvent event) {
-        if (event.getContainer() == windowModel) {
+        if (event.getSource() == windowModel) {
             synchronized (myStateLock) {
                 eventHandler.unregisterCallbacks();
                 windowModel.getConfigManager().removeListener(configListener);

--- a/src/com/dmdirc/ServerManager.java
+++ b/src/com/dmdirc/ServerManager.java
@@ -222,8 +222,8 @@ public class ServerManager implements ConnectionManager {
 
     @Handler
     void handleWindowClosing(final FrameClosingEvent event) {
-        if (event.getContainer() instanceof Server) {
-            unregisterServer((Server) event.getContainer());
+        if (event.getSource() instanceof Server) {
+            unregisterServer((Server) event.getSource());
         }
     }
 

--- a/src/com/dmdirc/events/DisplayableEvent.java
+++ b/src/com/dmdirc/events/DisplayableEvent.java
@@ -22,15 +22,13 @@
 
 package com.dmdirc.events;
 
-import com.dmdirc.interfaces.WindowModel;
-
 import java.time.LocalDateTime;
 import java.util.Optional;
 
 /**
  * Describes an event which is rendered in the client to the user.
  */
-public interface DisplayableEvent {
+public interface DisplayableEvent extends SourcedEvent {
 
     /**
      * Sets a property relating to how this event should be displayed.
@@ -77,10 +75,5 @@ public interface DisplayableEvent {
      * @return The time the event occurred at.
      */
     LocalDateTime getTimestamp();
-
-    /**
-     * Gets the source of the displayable event.
-     */
-    WindowModel getSource();
 
 }

--- a/src/com/dmdirc/events/FrameEvent.java
+++ b/src/com/dmdirc/events/FrameEvent.java
@@ -27,15 +27,17 @@ import com.dmdirc.interfaces.WindowModel;
 /**
  * Base class for window related events in the client.
  */
-public abstract class FrameEvent extends DMDircEvent {
+public abstract class FrameEvent extends DMDircEvent implements SourcedEvent {
 
-    private final WindowModel container;
+    private final WindowModel source;
 
-    public FrameEvent(final WindowModel container) {
-        this.container = container;
+    public FrameEvent(final WindowModel source) {
+        this.source = source;
     }
 
-    public WindowModel getContainer() {
-        return container;
+    @Override
+    public WindowModel getSource() {
+        return source;
     }
+
 }

--- a/src/com/dmdirc/events/SourcedEvent.java
+++ b/src/com/dmdirc/events/SourcedEvent.java
@@ -23,44 +23,15 @@
 package com.dmdirc.events;
 
 import com.dmdirc.interfaces.WindowModel;
-import com.dmdirc.ui.messages.UnreadStatusManager;
-import com.dmdirc.util.colours.Colour;
-
-import java.util.Optional;
 
 /**
- * Event raised when the unread status of a window has changed.
+ * An event that is attached to a {@link WindowModel} source.
  */
-public class UnreadStatusChangedEvent extends DMDircEvent implements SourcedEvent {
+public interface SourcedEvent {
 
-    private final WindowModel source;
-    private final UnreadStatusManager manager;
-    private final Optional<Colour> notificationColour;
-    private final int unreadCount;
-
-    public UnreadStatusChangedEvent(final WindowModel source, final UnreadStatusManager manager,
-            final Optional<Colour> notificationColour, final int unreadCount) {
-        this.source = source;
-        this.manager = manager;
-        this.notificationColour = notificationColour;
-        this.unreadCount = unreadCount;
-    }
-
-    @Override
-    public WindowModel getSource() {
-        return source;
-    }
-
-    public UnreadStatusManager getManager() {
-        return manager;
-    }
-
-    public Optional<Colour> getNotificationColour() {
-        return notificationColour;
-    }
-
-    public int getUnreadCount() {
-        return unreadCount;
-    }
+    /**
+     * Gets the source of the event.
+     */
+    WindowModel getSource();
 
 }

--- a/src/com/dmdirc/ui/WindowManager.java
+++ b/src/com/dmdirc/ui/WindowManager.java
@@ -411,7 +411,7 @@ public class WindowManager {
 
     @Handler
     public void frameClosing(final FrameClosingEvent event) {
-        removeWindow(event.getContainer());
+        removeWindow(event.getSource());
     }
 
 }

--- a/src/com/dmdirc/ui/input/InputHandler.java
+++ b/src/com/dmdirc/ui/input/InputHandler.java
@@ -675,7 +675,7 @@ public abstract class InputHandler implements ConfigChangeListener {
 
     @Handler
     void parentClosing(final FrameClosingEvent event) {
-        if (event.getContainer().equals(parentWindow)) {
+        if (event.getSource().equals(parentWindow)) {
             executorService.shutdown();
             eventBus.unsubscribe(this);
         }


### PR DESCRIPTION
For #662, it makes sense to have a standard way to
get the source from events we may wish to filter.

This introduces a SourcedEvent interface, and adapts classes
to use it.