### PR TITLE
Add source checks for eventbus handlers.

### DIFF
--- a/src/com/dmdirc/GroupChatManagerImpl.java
+++ b/src/com/dmdirc/GroupChatManagerImpl.java
@@ -194,11 +194,13 @@ public class GroupChatManagerImpl implements GroupChatManager {
 
     @Handler
     void handleChannelClosing(final ChannelClosedEvent event) {
-        final GroupChat channel = event.getChannel();
-        connection.getWindowModel().getInputModel().get().getTabCompleter()
-                .removeEntry(TabCompletionType.CHANNEL, channel.getName());
-        channels.remove(channel.getName());
-        channel.getEventBus().unsubscribe(this);
+        if (event.getChannel().getConnection().equals(connection)) {
+            final GroupChat channel = event.getChannel();
+            connection.getWindowModel().getInputModel().get().getTabCompleter()
+                    .removeEntry(TabCompletionType.CHANNEL, channel.getName());
+            channels.remove(channel.getName());
+            channel.getEventBus().unsubscribe(this);
+        }
     }
 
 }

--- a/src/com/dmdirc/Server.java
+++ b/src/com/dmdirc/Server.java
@@ -207,7 +207,9 @@ public class Server implements Connection {
         windowModel.getConfigManager().addChangeListener("formatter", "serverName", configListener);
         windowModel.getConfigManager().addChangeListener("formatter", "serverTitle", configListener);
 
-        this.highlightManager = new HighlightManager(windowModel.getConfigManager(),
+        this.highlightManager = new HighlightManager(
+                windowModel,
+                windowModel.getConfigManager(),
                 new ColourManager(windowModel.getConfigManager()));
         highlightManager.init();
         windowModel.getEventBus().subscribe(highlightManager);
@@ -705,7 +707,7 @@ public class Server implements Connection {
 
     @Handler
     private void handleClose(final FrameClosingEvent event) {
-        if (event.getSource() == windowModel) {
+        if (event.getSource().equals(windowModel)) {
             synchronized (myStateLock) {
                 eventHandler.unregisterCallbacks();
                 windowModel.getConfigManager().removeListener(configListener);

--- a/test/com/dmdirc/ui/messages/HighlightManagerTest.java
+++ b/test/com/dmdirc/ui/messages/HighlightManagerTest.java
@@ -32,6 +32,7 @@ import com.dmdirc.events.ServerNickChangeEvent;
 import com.dmdirc.interfaces.Connection;
 import com.dmdirc.interfaces.GroupChatUser;
 import com.dmdirc.interfaces.User;
+import com.dmdirc.interfaces.WindowModel;
 import com.dmdirc.interfaces.config.AggregateConfigProvider;
 
 import com.google.common.collect.Lists;
@@ -57,6 +58,7 @@ import static org.mockito.Mockito.when;
 public class HighlightManagerTest {
 
     @Mock private Connection connection;
+    @Mock private WindowModel windowModel;
     @Mock private User user;
     @Mock private Profile profile;
 
@@ -72,10 +74,11 @@ public class HighlightManagerTest {
     public void setup() {
         when(connection.getLocalUser()).thenReturn(Optional.of(user));
         when(connection.getProfile()).thenReturn(profile);
+        when(connection.getWindowModel()).thenReturn(windowModel);
 
         when(channel.getEventBus()).thenReturn(eventBus);
 
-        manager = new HighlightManager(configProvider, colourManager);
+        manager = new HighlightManager(windowModel, configProvider, colourManager);
     }
 
     @Test


### PR DESCRIPTION
In preparation for child eventbusses being removed, anything
trying to subscribe to specific windows now needs an explicit
check.

Issue #662