### PR TITLE
Change highlights into proper displayable events.

### DIFF
--- a/res/com/dmdirc/ui/messages/format.yml
+++ b/res/com/dmdirc/ui/messages/format.yml
@@ -126,6 +126,8 @@ ChannelSelfActionEvent:
   colour: 6
 ChannelMessageEvent:
   format: "<{{client.modePrefixedNickname}}> {{message}}"
+ChannelHighlightEvent:
+  format: "<{{client.modePrefixedNickname}}> {{message}}"
 ChannelSelfMessageEvent:
   format: "<{{client.modePrefixedNickname}}> {{message}}"
 ChannelModeNoticeEvent:
@@ -196,6 +198,8 @@ QuerySelfActionEvent:
   format: "* {{user.nickname}} {{message}}"
   colour: 6
 QueryMessageEvent:
+  format: "<{{user.nickname}}> {{message}}"
+QueryHighlightEvent:
   format: "<{{user.nickname}}> {{message}}"
 QuerySelfMessageEvent:
   format: "<{{user.nickname}}> {{message}}"

--- a/src/com/dmdirc/Server.java
+++ b/src/com/dmdirc/Server.java
@@ -51,7 +51,6 @@ import com.dmdirc.parser.interfaces.SecureParser;
 import com.dmdirc.parser.interfaces.StringConverter;
 import com.dmdirc.tls.CertificateManager;
 import com.dmdirc.ui.input.TabCompletionType;
-import com.dmdirc.ui.messages.ColourManager;
 import com.dmdirc.ui.messages.Formatter;
 import com.dmdirc.ui.messages.HighlightManager;
 
@@ -209,11 +208,7 @@ public class Server implements Connection {
         windowModel.getConfigManager().addChangeListener("formatter", "serverName", configListener);
         windowModel.getConfigManager().addChangeListener("formatter", "serverTitle", configListener);
 
-        this.highlightManager = new HighlightManager(
-                windowModel,
-                windowModel.getConfigManager(),
-                new ColourManager(windowModel.getConfigManager()));
-        highlightManager.init();
+        highlightManager = new HighlightManager(windowModel);
         windowModel.getEventBus().subscribe(highlightManager);
         windowModel.getEventBus().subscribe(this);
     }
@@ -690,7 +685,6 @@ public class Server implements Connection {
             synchronized (myStateLock) {
                 eventHandler.unregisterCallbacks();
                 windowModel.getConfigManager().removeListener(configListener);
-                highlightManager.stop();
                 windowModel.getEventBus().unsubscribe(highlightManager);
                 executorService.shutdown();
 

--- a/src/com/dmdirc/events/ChannelHighlightEvent.java
+++ b/src/com/dmdirc/events/ChannelHighlightEvent.java
@@ -22,20 +22,24 @@
 
 package com.dmdirc.events;
 
+import com.dmdirc.interfaces.GroupChat;
+import com.dmdirc.interfaces.GroupChatUser;
+
+import java.time.LocalDateTime;
+
 /**
  * Event raised when a highlight is detected in a channel.
  */
-public class ChannelHighlightEvent extends ChannelEvent {
+public class ChannelHighlightEvent extends ChannelMessageEvent {
 
-    private final ChannelEvent cause;
-
-    public ChannelHighlightEvent(final ChannelEvent cause) {
-        super(cause.getTimestamp(), cause.getChannel());
-        this.cause = cause;
+    public ChannelHighlightEvent(final LocalDateTime timestamp, final GroupChat channel,
+            final GroupChatUser client, final String message) {
+        super(timestamp, channel, client, message);
     }
 
-    public ChannelEvent getCause() {
-        return cause;
+    public ChannelHighlightEvent(final GroupChat channel, final GroupChatUser client,
+            final String message) {
+        super(channel, client, message);
     }
 
 }

--- a/src/com/dmdirc/events/QueryHighlightEvent.java
+++ b/src/com/dmdirc/events/QueryHighlightEvent.java
@@ -22,20 +22,23 @@
 
 package com.dmdirc.events;
 
+import com.dmdirc.Query;
+import com.dmdirc.interfaces.User;
+
+import java.time.LocalDateTime;
+
 /**
  * Event raised when a highlight is detected in a query.
  */
-public class QueryHighlightEvent extends QueryEvent {
+public class QueryHighlightEvent extends QueryMessageEvent {
 
-    private final QueryEvent cause;
-
-    public QueryHighlightEvent(final QueryEvent cause) {
-        super(cause.getTimestamp(), cause.getQuery());
-        this.cause = cause;
+    public QueryHighlightEvent(final LocalDateTime timestamp, final Query query, final User user,
+            final String message) {
+        super(timestamp, query, user, message);
     }
 
-    public QueryEvent getCause() {
-        return cause;
+    public QueryHighlightEvent(final Query query, final User user, final String message) {
+        super(query, user, message);
     }
 
 }

--- a/src/com/dmdirc/ui/messages/UnreadStatusManager.java
+++ b/src/com/dmdirc/ui/messages/UnreadStatusManager.java
@@ -82,14 +82,14 @@ public class UnreadStatusManager {
 
     @Handler
     public void handleChannelHighlightEvent(final ChannelHighlightEvent event) {
-        if (event.getCause().getChannel().equals(container)) {
+        if (event.getChannel().equals(container)) {
             updateStatus(highlightColour);
         }
     }
 
     @Handler
     public void handleQueryHighlightEvent(final QueryHighlightEvent event) {
-        if (event.getCause().getQuery().equals(container)) {
+        if (event.getQuery().equals(container)) {
             updateStatus(highlightColour);
         }
     }

--- a/test/com/dmdirc/ui/messages/HighlightManagerTest.java
+++ b/test/com/dmdirc/ui/messages/HighlightManagerTest.java
@@ -33,7 +33,6 @@ import com.dmdirc.interfaces.Connection;
 import com.dmdirc.interfaces.GroupChatUser;
 import com.dmdirc.interfaces.User;
 import com.dmdirc.interfaces.WindowModel;
-import com.dmdirc.interfaces.config.AggregateConfigProvider;
 
 import com.google.common.collect.Lists;
 
@@ -47,7 +46,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.only;
@@ -66,8 +65,6 @@ public class HighlightManagerTest {
     @Mock private GroupChatUser channelUser;
     @Mock private DMDircMBassador eventBus;
 
-    @Mock private ColourManager colourManager;
-    @Mock private AggregateConfigProvider configProvider;
     private HighlightManager manager;
 
     @Before
@@ -79,7 +76,7 @@ public class HighlightManagerTest {
         when(channel.getEventBus()).thenReturn(eventBus);
         when(channel.getConnection()).thenReturn(Optional.of(connection));
 
-        manager = new HighlightManager(windowModel, configProvider, colourManager);
+        manager = new HighlightManager(windowModel);
     }
 
     @Test
@@ -97,7 +94,9 @@ public class HighlightManagerTest {
                 ArgumentCaptor.forClass(ChannelHighlightEvent.class);
 
         verify(eventBus).publishAsync(captor.capture());
-        assertSame(event, captor.getValue().getCause());
+        assertEquals(channel, captor.getValue().getChannel());
+        assertEquals(channelUser, captor.getValue().getClient());
+        assertEquals("Hi, nickName!", captor.getValue().getMessage());
     }
 
     @Test
@@ -116,7 +115,9 @@ public class HighlightManagerTest {
                 ArgumentCaptor.forClass(ChannelHighlightEvent.class);
 
         verify(eventBus).publishAsync(captor.capture());
-        assertSame(event, captor.getValue().getCause());
+        assertEquals(channel, captor.getValue().getChannel());
+        assertEquals(channelUser, captor.getValue().getClient());
+        assertEquals("Hi, newName!", captor.getValue().getMessage());
     }
 
     @Test
@@ -149,7 +150,9 @@ public class HighlightManagerTest {
                 ArgumentCaptor.forClass(ChannelHighlightEvent.class);
 
         verify(eventBus).publishAsync(captor.capture());
-        assertSame(event, captor.getValue().getCause());
+        assertEquals(channel, captor.getValue().getChannel());
+        assertEquals(channelUser, captor.getValue().getClient());
+        assertEquals("DMDirc is great.", captor.getValue().getMessage());
     }
 
     @Test
@@ -168,7 +171,9 @@ public class HighlightManagerTest {
                 ArgumentCaptor.forClass(ChannelHighlightEvent.class);
 
         verify(eventBus, only()).publishAsync(captor.capture());
-        assertSame(event, captor.getValue().getCause());
+        assertEquals(channel, captor.getValue().getChannel());
+        assertEquals(channelUser, captor.getValue().getClient());
+        assertEquals("DMDirc is great.", captor.getValue().getMessage());
     }
 
 }


### PR DESCRIPTION
Instead of wrapping the source event and modifying it, they are
now proper events that are displayed themselves (and the original
message is suppressed).

This allows highlights to be formatted differently.

Issue #669