### PR TITLE
Specify background colour for highlight events.

### DIFF
--- a/res/com/dmdirc/config/defaults/default/defaults
+++ b/res/com/dmdirc/config/defaults/default/defaults
@@ -173,8 +173,6 @@ ui:
   miscellaneousNotificationColour=3
   messageNotificationColour=12
   highlightNotificationColour=4
-  highlightLineBackgroundColour=F9C4BB
-  highlightLineForegroundColour=
 
 treeview:
   dragSelection=true

--- a/res/com/dmdirc/ui/messages/format.yml
+++ b/res/com/dmdirc/ui/messages/format.yml
@@ -128,6 +128,7 @@ ChannelMessageEvent:
   format: "<{{client.modePrefixedNickname}}> {{message}}"
 ChannelHighlightEvent:
   format: "<{{client.modePrefixedNickname}}> {{message}}"
+  background: F9C4BB
 ChannelSelfMessageEvent:
   format: "<{{client.modePrefixedNickname}}> {{message}}"
 ChannelModeNoticeEvent:
@@ -201,6 +202,7 @@ QueryMessageEvent:
   format: "<{{user.nickname}}> {{message}}"
 QueryHighlightEvent:
   format: "<{{user.nickname}}> {{message}}"
+  background: F9C4BB
 QuerySelfMessageEvent:
   format: "<{{user.nickname}}> {{message}}"
 QueryQuitEvent:

--- a/src/com/dmdirc/ui/messages/HighlightManager.java
+++ b/src/com/dmdirc/ui/messages/HighlightManager.java
@@ -61,7 +61,7 @@ public class HighlightManager {
         if (event.getChannel().getConnection().get().getWindowModel().equals(serverWindow)
                 && patterns.stream().anyMatch(p -> p.matcher(event.getMessage()).matches())) {
             event.setDisplayProperty(DisplayProperty.DO_NOT_DISPLAY, true);
-            event.getChannel().getEventBus().publishAsync(
+            event.getChannel().getEventBus().publish(
                     new ChannelHighlightEvent(
                             event.getTimestamp(), event.getChannel(), event.getClient(),
                             event.getMessage()));
@@ -73,7 +73,7 @@ public class HighlightManager {
         if (event.getUser().getConnection().getWindowModel().equals(serverWindow)
                 && patterns.stream().anyMatch(p -> p.matcher(event.getMessage()).matches())) {
             event.setDisplayProperty(DisplayProperty.DO_NOT_DISPLAY, true);
-            event.getQuery().getEventBus().publishAsync(
+            event.getQuery().getEventBus().publish(
                     new QueryHighlightEvent(
                             event.getTimestamp(), event.getQuery(), event.getUser(),
                             event.getMessage()));

--- a/src/com/dmdirc/ui/messages/YamlEventFormatProvider.java
+++ b/src/com/dmdirc/ui/messages/YamlEventFormatProvider.java
@@ -25,6 +25,7 @@ package com.dmdirc.ui.messages;
 import com.dmdirc.events.DisplayProperty;
 import com.dmdirc.events.DisplayPropertyMap;
 import com.dmdirc.events.DisplayableEvent;
+import com.dmdirc.util.colours.Colour;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -112,8 +113,13 @@ public class YamlEventFormatProvider implements EventFormatProvider {
         final DisplayPropertyMap map = new DisplayPropertyMap();
         if (info.containsKey("colour")) {
             map.put(DisplayProperty.FOREGROUND_COLOUR,
-                    colourManager.getColourFromIrcCode(
-                            Integer.parseInt(info.get("colour").toString())));
+                    colourManager.getColourFromString(
+                            info.get("colour").toString(), Colour.BLACK));
+        }
+        if (info.containsKey("background")) {
+            map.put(DisplayProperty.BACKGROUND_COLOUR,
+                    colourManager.getColourFromString(
+                            info.get("background").toString(), Colour.BLACK));
         }
         if (info.containsKey("timestamp")) {
             map.put(DisplayProperty.NO_TIMESTAMPS,

--- a/test/com/dmdirc/ui/messages/HighlightManagerTest.java
+++ b/test/com/dmdirc/ui/messages/HighlightManagerTest.java
@@ -93,7 +93,7 @@ public class HighlightManagerTest {
         final ArgumentCaptor<ChannelHighlightEvent> captor =
                 ArgumentCaptor.forClass(ChannelHighlightEvent.class);
 
-        verify(eventBus).publishAsync(captor.capture());
+        verify(eventBus).publish(captor.capture());
         assertEquals(channel, captor.getValue().getChannel());
         assertEquals(channelUser, captor.getValue().getClient());
         assertEquals("Hi, nickName!", captor.getValue().getMessage());
@@ -114,7 +114,7 @@ public class HighlightManagerTest {
         final ArgumentCaptor<ChannelHighlightEvent> captor =
                 ArgumentCaptor.forClass(ChannelHighlightEvent.class);
 
-        verify(eventBus).publishAsync(captor.capture());
+        verify(eventBus).publish(captor.capture());
         assertEquals(channel, captor.getValue().getChannel());
         assertEquals(channelUser, captor.getValue().getClient());
         assertEquals("Hi, newName!", captor.getValue().getMessage());
@@ -132,7 +132,7 @@ public class HighlightManagerTest {
         manager.handleNickChange(new ServerNickChangeEvent(connection, "nickName", "newName"));
         manager.handleChannelMessage(event);
 
-        verify(eventBus, never()).publishAsync(any());
+        verify(eventBus, never()).publish(any());
     }
 
     @Test
@@ -149,7 +149,7 @@ public class HighlightManagerTest {
         final ArgumentCaptor<ChannelHighlightEvent> captor =
                 ArgumentCaptor.forClass(ChannelHighlightEvent.class);
 
-        verify(eventBus).publishAsync(captor.capture());
+        verify(eventBus).publish(captor.capture());
         assertEquals(channel, captor.getValue().getChannel());
         assertEquals(channelUser, captor.getValue().getClient());
         assertEquals("DMDirc is great.", captor.getValue().getMessage());
@@ -170,7 +170,7 @@ public class HighlightManagerTest {
         final ArgumentCaptor<ChannelHighlightEvent> captor =
                 ArgumentCaptor.forClass(ChannelHighlightEvent.class);
 
-        verify(eventBus, only()).publishAsync(captor.capture());
+        verify(eventBus, only()).publish(captor.capture());
         assertEquals(channel, captor.getValue().getChannel());
         assertEquals(channelUser, captor.getValue().getClient());
         assertEquals("DMDirc is great.", captor.getValue().getMessage());


### PR DESCRIPTION
Allow colours in formats to be hex. Closes #631.

Fix ordering of highlighted messages. #669.