### PR TITLE
Tidy up nick change handling.

### DIFF
--- a/src/main/java/com/dmdirc/Query.java
+++ b/src/main/java/com/dmdirc/Query.java
@@ -45,11 +45,12 @@ import com.dmdirc.parser.interfaces.ClientInfo;
 import com.dmdirc.parser.interfaces.Parser;
 import com.dmdirc.ui.core.components.WindowComponent;
 import com.dmdirc.ui.messages.BackBufferFactory;
-import net.engio.mbassy.listener.Handler;
 
-import java.awt.*;
+import java.awt.Toolkit;
 import java.util.Arrays;
 import java.util.Optional;
+
+import net.engio.mbassy.listener.Handler;
 
 /**
  * The Query class represents the client's view of a query with another user. It handles callbacks

--- a/src/main/java/com/dmdirc/Query.java
+++ b/src/main/java/com/dmdirc/Query.java
@@ -45,12 +45,11 @@ import com.dmdirc.parser.interfaces.ClientInfo;
 import com.dmdirc.parser.interfaces.Parser;
 import com.dmdirc.ui.core.components.WindowComponent;
 import com.dmdirc.ui.messages.BackBufferFactory;
+import net.engio.mbassy.listener.Handler;
 
-import java.awt.Toolkit;
+import java.awt.*;
 import java.util.Arrays;
 import java.util.Optional;
-
-import net.engio.mbassy.listener.Handler;
 
 /**
  * The Query class represents the client's view of a query with another user. It handles callbacks
@@ -176,8 +175,6 @@ public class Query extends FrameContainer implements PrivateChat {
         final ClientInfo client = event.getClient();
         final String oldNick = event.getOldNick();
         if (client.getNickname().equals(getNickname())) {
-            connection.updateQuery(this, oldNick, client.getNickname());
-
             getEventBus().publish(new QueryNickChangeEvent(this, oldNick, client.getNickname()));
             updateTitle();
 

--- a/src/main/java/com/dmdirc/ServerEventHandler.java
+++ b/src/main/java/com/dmdirc/ServerEventHandler.java
@@ -86,14 +86,17 @@ import com.dmdirc.parser.events.WallDesyncEvent;
 import com.dmdirc.parser.events.WallopEvent;
 import com.dmdirc.parser.events.WalluserEvent;
 import com.dmdirc.ui.StatusMessage;
-import net.engio.mbassy.listener.Handler;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
+
+import javax.annotation.Nonnull;
+
+import net.engio.mbassy.listener.Handler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static com.dmdirc.util.LogUtils.APP_ERROR;
 import static com.dmdirc.util.LogUtils.USER_ERROR;

--- a/src/main/java/com/dmdirc/ServerEventHandler.java
+++ b/src/main/java/com/dmdirc/ServerEventHandler.java
@@ -86,17 +86,14 @@ import com.dmdirc.parser.events.WallDesyncEvent;
 import com.dmdirc.parser.events.WallopEvent;
 import com.dmdirc.parser.events.WalluserEvent;
 import com.dmdirc.ui.StatusMessage;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.Random;
-
-import javax.annotation.Nonnull;
-
+import net.engio.mbassy.listener.Handler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import net.engio.mbassy.listener.Handler;
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
 
 import static com.dmdirc.util.LogUtils.APP_ERROR;
 import static com.dmdirc.util.LogUtils.USER_ERROR;
@@ -408,6 +405,8 @@ public class ServerEventHandler extends EventHandler {
                     event.getOldNick(), event.getClient().getNickname()));
             owner.updateTitle();
         }
+
+        owner.handleNickChange(event.getClient(), event.getOldNick());
     }
 
     @Handler

--- a/src/main/java/com/dmdirc/interfaces/Connection.java
+++ b/src/main/java/com/dmdirc/interfaces/Connection.java
@@ -30,11 +30,10 @@ import com.dmdirc.interfaces.config.ConfigProvider;
 import com.dmdirc.parser.common.IgnoreList;
 import com.dmdirc.parser.interfaces.Parser;
 
+import javax.annotation.Nonnull;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Optional;
-
-import javax.annotation.Nonnull;
 
 /**
  * Represents an abstract connection to a remote chat system.
@@ -291,19 +290,6 @@ public interface Connection {
      * Updates this server's ignore list to use the entries stored in the config manager.
      */
     void updateIgnoreList();
-
-    /**
-     * Updates the state of this server following a nick change of someone that the user has a query
-     * open with. Namely, this updates the tabcompleter with the new name, and ensures that the
-     * <code>queries</code> map uses the correct nickname.
-     *
-     * @param query   The query object being updated
-     * @param oldNick The old nickname of the user
-     * @param newNick The new nickname of the user
-     *
-     * @since 0.6.4
-     */
-    void updateQuery(final Query query, final String oldNick, final String newNick);
 
     /**
      * Updates the name and title of this window.

--- a/src/main/java/com/dmdirc/interfaces/Connection.java
+++ b/src/main/java/com/dmdirc/interfaces/Connection.java
@@ -30,10 +30,11 @@ import com.dmdirc.interfaces.config.ConfigProvider;
 import com.dmdirc.parser.common.IgnoreList;
 import com.dmdirc.parser.interfaces.Parser;
 
-import javax.annotation.Nonnull;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Optional;
+
+import javax.annotation.Nonnull;
 
 /**
  * Represents an abstract connection to a remote chat system.


### PR DESCRIPTION
It doesn't make sense to have a public method in Connection to
muddle around with how queries are tracked, nor for queries to
tell servers when they change (creating a dependency loop).

Instead, have the ServerEventHandler tell Server.