### PR TITLE
Make LogUtils try some more ctors.

### DIFF
--- a/src/main/java/com/dmdirc/util/LogUtils.java
+++ b/src/main/java/com/dmdirc/util/LogUtils.java
@@ -133,7 +133,17 @@ public final class LogUtils {
             }
 
             if (throwable == null) {
-                throw new ReflectiveOperationException("Unable to find ctor of " + clazz);
+                try {
+                    // Or maybe just a throwable?
+                    throwable = clazz.getConstructor(Throwable.class).newInstance(getThrowable(proxy.getCause()));
+                } catch (NoSuchMethodException ex) {
+                    try {
+                        throwable = clazz.getConstructor(String.class).newInstance(proxy.getMessage());
+                    } catch (NoSuchMethodException ex2) {
+                        // *Shrug*
+                        throw new ReflectiveOperationException("Unable to find ctor of " + clazz);
+                    }
+                }
             }
         }
         throwable.setStackTrace(getStackTraceElements(proxy.getStackTraceElementProxyArray()));


### PR DESCRIPTION
NoClassDefFoundError only takes a message (no source). Try
throwable-only and message-only ctors in addition to the
two-arg ctors.