### PR TITLE
Add config annotations to API.

### DIFF
--- a/api/src/main/java/com/dmdirc/config/AddonConfig.java
+++ b/api/src/main/java/com/dmdirc/config/AddonConfig.java
@@ -1,0 +1,10 @@
+package com.dmdirc.config;
+
+import javax.inject.Qualifier;
+
+/**
+ * Qualifier that identities the addon defaults config provider.
+ */
+@Qualifier
+public @interface AddonConfig {
+}

--- a/api/src/main/java/com/dmdirc/config/GlobalConfig.java
+++ b/api/src/main/java/com/dmdirc/config/GlobalConfig.java
@@ -1,0 +1,10 @@
+package com.dmdirc.config;
+
+import javax.inject.Qualifier;
+
+/**
+ * Qualifier that identities a global configuration source.
+ */
+@Qualifier
+public @interface GlobalConfig {
+}

--- a/api/src/main/java/com/dmdirc/config/UserConfig.java
+++ b/api/src/main/java/com/dmdirc/config/UserConfig.java
@@ -1,0 +1,10 @@
+package com.dmdirc.config;
+
+import javax.inject.Qualifier;
+
+/**
+ * Qualifier that identities the user settings config provider.
+ */
+@Qualifier
+public @interface UserConfig {
+}

--- a/src/main/java/com/dmdirc/ClientModule.java
+++ b/src/main/java/com/dmdirc/ClientModule.java
@@ -149,8 +149,15 @@ public class ClientModule {
     @Provides
     @Singleton
     @GlobalConfig
+    public ColourManager getOldGlobalColourManager(@com.dmdirc.config.GlobalConfig final ColourManager colourManager) {
+        return colourManager;
+    }
+
+    @Provides
+    @Singleton
+    @com.dmdirc.config.GlobalConfig
     public ColourManager getGlobalColourManager(final ColourManagerFactory colourManagerFactory,
-            @GlobalConfig final  AggregateConfigProvider globalConfig) {
+            @com.dmdirc.config.GlobalConfig final AggregateConfigProvider globalConfig) {
         return colourManagerFactory.getColourManager(globalConfig);
     }
 

--- a/src/main/java/com/dmdirc/config/ConfigModule.java
+++ b/src/main/java/com/dmdirc/config/ConfigModule.java
@@ -43,9 +43,6 @@ import javax.inject.Singleton;
 import dagger.Module;
 import dagger.Provides;
 
-import static com.dmdirc.ClientModule.AddonConfig;
-import static com.dmdirc.ClientModule.GlobalConfig;
-import static com.dmdirc.ClientModule.UserConfig;
 import static com.dmdirc.commandline.CommandLineOptionsModule.Directory;
 import static com.dmdirc.commandline.CommandLineOptionsModule.DirectoryType;
 
@@ -88,15 +85,33 @@ public class ConfigModule {
     }
 
     @Provides
+    @com.dmdirc.ClientModule.GlobalConfig
+    public AggregateConfigProvider getOldGlobalConfig(final IdentityController controller) {
+        return controller.getGlobalConfiguration();
+    }
+
+    @Provides
     @GlobalConfig
     public AggregateConfigProvider getGlobalConfig(final IdentityController controller) {
         return controller.getGlobalConfiguration();
     }
 
     @Provides
+    @com.dmdirc.ClientModule.UserConfig
+    public ConfigProvider getOldUserConfig(final IdentityController controller) {
+        return controller.getUserSettings();
+    }
+
+    @Provides
     @UserConfig
     public ConfigProvider getUserConfig(final IdentityController controller) {
         return controller.getUserSettings();
+    }
+
+    @Provides
+    @com.dmdirc.ClientModule.AddonConfig
+    public ConfigProvider getOldAddonConfig(final IdentityController controller) {
+        return controller.getAddonSettings();
     }
 
     @Provides


### PR DESCRIPTION
At present anything requesting the global config has to depend on
ClientModule, which won't necessarily be exposed through the API.

Move @GlobalConfig, @AddonConfig and @UserConfig to top level
classes in API, and provide both versions of them for now.