### PR TITLE
Add dummy version.config.

### DIFF
--- a/src/main/resources/com/dmdirc/version.config
+++ b/src/main/resources/com/dmdirc/version.config
@@ -1,0 +1,20 @@
+# This is a dummy version.config file that should be replaced by the build process.
+
+keysections:
+ identity
+ version
+ updater
+ bundledplugins_versions
+
+identity:
+ name=DMDirc version information
+ globaldefault=true
+ order=95000
+
+version:
+ version=0.0.0
+
+updater:
+ channel=DEV
+
+buildenv:


### PR DESCRIPTION
This allows running DMDirc from IDEA, which seems useful.

Running a normal build just replaces the file in the build output.