### PR TITLE
Move static styliser methods to new class.

### DIFF
--- a/src/main/java/com/dmdirc/Channel.java
+++ b/src/main/java/com/dmdirc/Channel.java
@@ -44,10 +44,8 @@ import com.dmdirc.parser.interfaces.Parser;
 import com.dmdirc.ui.core.components.WindowComponent;
 import com.dmdirc.ui.input.TabCompletionType;
 import com.dmdirc.ui.messages.BackBufferFactory;
-import com.dmdirc.ui.messages.Styliser;
-
+import com.dmdirc.ui.messages.StyledMessageUtils;
 import com.google.common.collect.EvictingQueue;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -56,7 +54,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.stream.Collectors;
-
 import javax.annotation.Nullable;
 
 /**
@@ -98,7 +95,7 @@ public class Channel extends FrameContainer implements GroupChat {
             final GroupChatUserManager groupChatUserManager) {
         super("channel-inactive",
                 newChannelInfo.getName(),
-                Styliser.stipControlCodes(newChannelInfo.getName()),
+                new StyledMessageUtils().stripControlCodes(newChannelInfo.getName()), // TODO: Inject this
                 configMigrator.getConfigProvider(),
                 backBufferFactory,
                 connection.getWindowModel().getEventBus(),
@@ -220,12 +217,12 @@ public class Channel extends FrameContainer implements GroupChat {
      * Updates the title of the channel window, and of the main window if appropriate.
      */
     private void updateTitle() {
-        String temp = Styliser.stipControlCodes(channelInfo.getName());
+        final StyledMessageUtils styleUtils = new StyledMessageUtils();
 
+        String temp = styleUtils.stripControlCodes(channelInfo.getName());
         if (!channelInfo.getTopic().isEmpty()) {
-            temp += " - " + Styliser.stipControlCodes(channelInfo.getTopic());
+            temp += " - " + styleUtils.stripControlCodes(channelInfo.getTopic());
         }
-
         setTitle(temp);
     }
 

--- a/src/main/java/com/dmdirc/ui/messages/IRCLine.java
+++ b/src/main/java/com/dmdirc/ui/messages/IRCLine.java
@@ -35,6 +35,7 @@ public class IRCLine implements Line {
     private final String timestamp;
     private final String text;
     private final Styliser styliser;
+    private final StyledMessageUtils styleUtils = new StyledMessageUtils(); // TODO: Inject
     private final DisplayPropertyMap displayProperties;
     private int fontSize;
     private String fontName;
@@ -94,7 +95,7 @@ public class IRCLine implements Line {
 
     @Override
     public String getText() {
-        return Styliser.stipControlCodes(timestamp + text);
+        return styleUtils.stripControlCodes(timestamp + text);
     }
 
     @Override

--- a/src/main/java/com/dmdirc/ui/messages/StyledMessageUtils.java
+++ b/src/main/java/com/dmdirc/ui/messages/StyledMessageUtils.java
@@ -1,0 +1,100 @@
+package com.dmdirc.ui.messages;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import static com.dmdirc.ui.messages.Styliser.CODE_CHANNEL;
+import static com.dmdirc.ui.messages.Styliser.CODE_HYPERLINK;
+import static com.dmdirc.ui.messages.Styliser.CODE_NICKNAME;
+import static com.dmdirc.ui.messages.Styliser.CODE_SMILIE;
+import static com.dmdirc.ui.messages.Styliser.CODE_TOOLTIP;
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Utilities for dealing with styled messages.
+ */
+@Singleton
+public class StyledMessageUtils {
+
+    @Inject
+    public StyledMessageUtils() {
+    }
+
+    /**
+     * Strips all recognised control codes from the input string.
+     *
+     * @param input the String to be stripped
+     *
+     * @return a copy of the input with control codes removed
+     */
+    public String stripControlCodes(final String input) {
+        return input.replaceAll("[" + IRCControlCodes.BOLD + CODE_CHANNEL + IRCControlCodes.FIXED
+                + CODE_HYPERLINK + IRCControlCodes.ITALIC + IRCControlCodes.NEGATE + CODE_NICKNAME
+                + CODE_SMILIE + IRCControlCodes.STOP + IRCControlCodes.UNDERLINE + "]|"
+                + IRCControlCodes.COLOUR_HEX + "([A-Za-z0-9]{6}(,[A-Za-z0-9]{6})?)?|"
+                + IRCControlCodes.COLOUR + "([0-9]{1,2}(,[0-9]{1,2})?)?", "")
+                .replaceAll(CODE_TOOLTIP + ".*?" + CODE_TOOLTIP + "(.*?)" + CODE_TOOLTIP, "$1");
+    }
+
+    /**
+     * Retrieves the styled String contained within the unstyled offsets specified. That is, the
+     * <code>from</code> and <code>to</code> arguments correspond to indexes in an unstyled version
+     * of the <code>styled</code> string. The unstyled indices are translated to offsets within the
+     * styled String, and the return value includes all text and control codes between those
+     * indices.
+     * <p>
+     * The index translation is left-biased; that is, the indices are translated to be as far left
+     * as they possibly can be. This means that the start of the string will include any control
+     * codes immediately preceding the desired text, and the end will not include any trailing
+     * codes.
+     * <p>
+     * This method will NOT include "internal" control codes in the output.
+     *
+     * @param styled The styled String to be operated on
+     * @param from   The starting index in the unstyled string
+     * @param to     The ending index in the unstyled string
+     *
+     * @return The corresponding text between the two indices
+     */
+    public String getStyledText(final String styled, final int from, final int to) {
+        checkArgument(from < to, "'from' (" + from + ") must be less than 'to' (" + to + ')');
+        checkArgument(from >= 0, "'from' (" + from + ") must be non-negative");
+
+        final String unstyled = stripControlCodes(styled);
+
+        checkArgument(to <= unstyled.length(), "'to' (" + to + ") must be less than or equal to "
+                + "the unstyled length (" + unstyled.length() + ')');
+
+        final String startBit = unstyled.substring(0, from);
+        final String middleBit = unstyled.substring(from, to);
+        final String sanitised = stripInternalControlCodes(styled);
+        int start = from;
+
+        while (!stripControlCodes(sanitised.substring(0, start)).equals(startBit)) {
+            start++;
+        }
+
+        int end = to + start - from;
+
+        while (!stripControlCodes(sanitised.substring(start, end)).equals(middleBit)) {
+            end++;
+        }
+
+        return sanitised.substring(start, end);
+    }
+
+    /**
+     * Strips all recognised internal control codes from the input string.
+     *
+     * @param input the String to be stripped
+     *
+     * @return a copy of the input with control codes removed
+     */
+    private String stripInternalControlCodes(final String input) {
+        return input.replaceAll("[" + CODE_CHANNEL + CODE_HYPERLINK + CODE_NICKNAME
+                + CODE_SMILIE + IRCControlCodes.STOP + IRCControlCodes.UNDERLINE + ']', "")
+                .replaceAll(CODE_TOOLTIP + ".*?" + CODE_TOOLTIP + "(.*?)"
+                        + CODE_TOOLTIP, "$1");
+    }
+
+}

--- a/src/main/java/com/dmdirc/ui/messages/Styliser.java
+++ b/src/main/java/com/dmdirc/ui/messages/Styliser.java
@@ -22,15 +22,16 @@
 
 package com.dmdirc.ui.messages;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.dmdirc.interfaces.Connection;
 import com.dmdirc.interfaces.config.AggregateConfigProvider;
 import com.dmdirc.interfaces.config.ConfigChangeListener;
 import com.dmdirc.util.colours.Colour;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Locale;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * The styliser applies IRC styles to text. Styles are indicated by various control codes which are
@@ -195,7 +196,9 @@ public class Styliser implements ConfigChangeListener {
      * @return The corresponding text between the two indices
      *
      * @since 0.6.3
+     * @deprecated Use {@link StyledMessageUtils}
      */
+    @Deprecated
     public static String getStyledText(final String styled, final int from, final int to) {
         checkArgument(from < to, "'from' (" + from + ") must be less than 'to' (" + to + ')');
         checkArgument(from >= 0, "'from' (" + from + ") must be non-negative");
@@ -289,7 +292,9 @@ public class Styliser implements ConfigChangeListener {
      * @param input the String to be stripped
      *
      * @return a copy of the input with control codes removed
+     * @deprecated Use {@link StyledMessageUtils}
      */
+    @Deprecated
     public static String stipControlCodes(final String input) {
         return input.replaceAll("[" + IRCControlCodes.BOLD + CODE_CHANNEL + IRCControlCodes.FIXED
                 + CODE_HYPERLINK + IRCControlCodes.ITALIC + IRCControlCodes.NEGATE + CODE_NICKNAME
@@ -308,6 +313,7 @@ public class Styliser implements ConfigChangeListener {
      *
      * @since 0.6.5
      */
+    @Deprecated
     private static String stipInternalControlCodes(final String input) {
         return input.replaceAll("[" + CODE_CHANNEL + CODE_HYPERLINK + CODE_NICKNAME
                 + CODE_SMILIE + IRCControlCodes.STOP + IRCControlCodes.UNDERLINE + ']', "")
@@ -324,7 +330,8 @@ public class Styliser implements ConfigChangeListener {
      *
      * @return A substring of the input containing no control characters
      */
-    public static String readUntilControl(final String input) {
+    @VisibleForTesting
+    static String readUntilControl(final String input) {
         int pos = input.length();
 
         pos = checkChar(pos, input.indexOf(IRCControlCodes.BOLD));

--- a/src/test/java/com/dmdirc/ui/messages/StyledMessageUtilsTest.java
+++ b/src/test/java/com/dmdirc/ui/messages/StyledMessageUtilsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2006-2016 DMDirc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.dmdirc.ui.messages;
+
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class StyledMessageUtilsTest {
+
+    private StyledMessageUtils styleUtils;
+
+    @Before
+    public void setUp() {
+        styleUtils = new StyledMessageUtils();
+    }
+
+    @Test
+    public void testStripControlCodes1() {
+        final String input = "This"+ (char) 2 +" is "+ (char) 17 +"a test";
+
+        final String expResult = "This is a test";
+        final String result = styleUtils.stripControlCodes(input);
+        assertEquals(expResult, result);
+    }
+
+    @Test
+    public void testStripControlCodes2() {
+        final String input = "This is "+ (char) 3 +"5a "+ (char) 4 +"FF0000test";
+
+        final String expResult = "This is a test";
+        final String result = styleUtils.stripControlCodes(input);
+        assertEquals(expResult, result);
+    }
+
+}

--- a/src/test/java/com/dmdirc/ui/messages/StyliserIndicesTest.java
+++ b/src/test/java/com/dmdirc/ui/messages/StyliserIndicesTest.java
@@ -34,8 +34,8 @@ import static org.junit.Assert.*;
 @RunWith(Parameterized.class)
 public class StyliserIndicesTest {
 
-    protected String input, output;
-    protected int start, end;
+    private String input, output;
+    private int start, end;
 
     public StyliserIndicesTest(final String input, final int start, final int end, final String output) {
         this.input = input;
@@ -46,7 +46,7 @@ public class StyliserIndicesTest {
 
     @Test
     public void testStyle() {
-        assertEquals(output, Styliser.getStyledText(input, start, end));
+        assertEquals(output, new StyledMessageUtils().getStyledText(input, start, end));
     }
 
     @Parameterized.Parameters

--- a/src/test/java/com/dmdirc/ui/messages/StyliserTest.java
+++ b/src/test/java/com/dmdirc/ui/messages/StyliserTest.java
@@ -40,24 +40,6 @@ public class StyliserTest {
     @Mock private EventBus eventBus;
 
     @Test
-    public void testStripControlCodes1() {
-        final String input = "This"+ (char) 2 +" is "+ (char) 17 +"a test";
-
-        final String expResult = "This is a test";
-        final String result = Styliser.stipControlCodes(input);
-        assertEquals(expResult, result);
-    }
-
-    @Test
-    public void testStripControlCodes2() {
-        final String input = "This is "+ (char) 3 +"5a "+ (char) 4 +"FF0000test";
-
-        final String expResult = "This is a test";
-        final String result = Styliser.stipControlCodes(input);
-        assertEquals(expResult, result);
-    }
-
-    @Test
     public void testReadUntilControl1() {
         final String input = "This"+ (char) 2 +" is "+ (char) 17 +"a test";
         final String expResult = "This";


### PR DESCRIPTION
The styliser needs an interface extracting into the API, and
we don't really want huge static methods defined on that.