### PR TITLE
Add base interface for objects with display properties.

### DIFF
--- a/api/src/main/java/com/dmdirc/events/DisplayableEvent.java
+++ b/api/src/main/java/com/dmdirc/events/DisplayableEvent.java
@@ -22,52 +22,13 @@
 
 package com.dmdirc.events;
 
+import com.dmdirc.interfaces.Displayable;
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 /**
  * Describes an event which is rendered in the client to the user.
  */
-public interface DisplayableEvent extends SourcedEvent {
-
-    /**
-     * Sets a property relating to how this event should be displayed.
-     *
-     * @param property The property to be set
-     * @param value The value of the property
-     * @param <T> The type of value that the property takes.
-     */
-    <T> void setDisplayProperty(DisplayProperty<T> property, T value);
-
-    /**
-     * Retrieves a property relating to how this event should be displayed.
-     *
-     * @param property The property to be retrieved.
-     * @param <T> The type of value that the property takes.
-     * @return An optional value for the property.
-     */
-    <T> Optional<T> getDisplayProperty(DisplayProperty<T> property);
-
-    /**
-     * Determines whether this event has a display property.
-     *
-     * <p>Only use this method if the value of the property does not matter; otherwise use
-     * {@link #getDisplayProperty(DisplayProperty)} and use the appropriate {@link Optional}
-     * accessors.
-     *
-     * @param property The property to be checked.
-     * @return True if the property is present, false otherwise.
-     */
-    default boolean hasDisplayProperty(final DisplayProperty<?> property) {
-        return getDisplayProperty(property).isPresent();
-    }
-
-    /**
-     * Gets the map of all display properties.
-     *
-     * @return The map of display properties.
-     */
-    DisplayPropertyMap getDisplayProperties();
+public interface DisplayableEvent extends SourcedEvent, Displayable {
 
     /**
      * Gets the times at which the event occurred.

--- a/api/src/main/java/com/dmdirc/interfaces/Displayable.java
+++ b/api/src/main/java/com/dmdirc/interfaces/Displayable.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2006-2016 DMDirc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+ * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.dmdirc.interfaces;
+
+import com.dmdirc.events.DisplayProperty;
+import com.dmdirc.events.DisplayPropertyMap;
+import java.util.Optional;
+
+/**
+ * Common interface for objects which may be displayed, and are affected by {@link DisplayProperty}s.
+ */
+public interface Displayable {
+
+    /**
+     * Retrieves a property relating to how this object should be displayed.
+     *
+     * @param property The property to be retrieved.
+     * @param <T> The type of value that the property takes.
+     * @return An optional value for the property.
+     */
+    <T> Optional<T> getDisplayProperty(DisplayProperty<T> property);
+
+    /**
+     * Sets a property relating to how this object should be displayed.
+     *
+     * @param property The property to be set
+     * @param value The value of the property
+     * @param <T> The type of value that the property takes.
+     */
+    <T> void setDisplayProperty(DisplayProperty<T> property, T value);
+
+    /**
+     * Determines whether this object has a display property.
+     *
+     * <p>Only use this method if the value of the property does not matter; otherwise use
+     * {@link #getDisplayProperty(DisplayProperty)} and use the appropriate {@link Optional}
+     * accessors.
+     *
+     * @param property The property to be checked.
+     * @return True if the property is present, false otherwise.
+     */
+    default boolean hasDisplayProperty(final DisplayProperty<?> property) {
+        return getDisplayProperty(property).isPresent();
+    }
+
+    /**
+     * Removes a property relating to how this object should be displayed.
+     *
+     * @param property The property to be removed
+     */
+    default <T> void removeDisplayProperty(final DisplayProperty<T> property) {
+        getDisplayProperties().remove(property);
+    }
+
+    /**
+     * Gets the map of all display properties.
+     *
+     * @return The map of display properties.
+     */
+    DisplayPropertyMap getDisplayProperties();
+
+}

--- a/api/src/main/java/com/dmdirc/interfaces/GroupChatUser.java
+++ b/api/src/main/java/com/dmdirc/interfaces/GroupChatUser.java
@@ -22,16 +22,13 @@
 
 package com.dmdirc.interfaces;
 
-import com.dmdirc.events.DisplayProperty;
-import com.dmdirc.events.DisplayPropertyMap;
-
 import java.util.Comparator;
 import java.util.Optional;
 
 /**
  * Describes a {@link User} that is present on a {@link GroupChat}.
  */
-public interface GroupChatUser {
+public interface GroupChatUser extends Displayable {
 
     /**
      * Retrieves the {@link User} object which this object corresponds
@@ -107,33 +104,4 @@ public interface GroupChatUser {
      */
     Comparator<String> getModeComparator();
 
-    /**
-     * Sets a property relating to how this {@link GroupChatUser} should be displayed.
-     *
-     * @param property The property to be set
-     * @param value The value of the property
-     * @param <T> The type of value that the property takes.
-     */
-    <T> void setDisplayProperty(final DisplayProperty<T> property, final T value);
-
-    /**
-     * Retrieves a property relating to how this {@link GroupChatUser} should be displayed.
-     *
-     * @param property The property to be retrieved.
-     * @param <T> The type of value that the property takes.
-     * @return An optional value for the property.
-     */
-    <T> Optional<T> getDisplayProperty(final DisplayProperty<T> property);
-
-    /**
-     * Removes a property relating to how this {@link GroupChatUser} should be displayed.
-     */
-    <T> void removeDisplayProperty(final DisplayProperty<T> property);
-
-    /**
-     * Gets the map of all display properties for this {@link GroupChatUser}.
-     *
-     * @return The map of display properties.
-     */
-    DisplayPropertyMap getDisplayProperties();
 }


### PR DESCRIPTION
This will allow the formatter to check if strings coming from
(for example) users in channels should be formatted specially,
such as by colouring or linking them.

Issues #424 and DMDirc/Plugins#507