### PR TITLE
Apply object display properties when formatting events.

### DIFF
--- a/src/main/java/com/dmdirc/ui/messages/EventPropertyManager.java
+++ b/src/main/java/com/dmdirc/ui/messages/EventPropertyManager.java
@@ -61,10 +61,8 @@ public class EventPropertyManager {
         functions.put("bracketed", s -> Strings.isNullOrEmpty(s) ? "" : " (" + s + ')');
     }
 
-    public <S> Optional<Object> getProperty(final S object, final Class<? extends S> type,
-            final String property) {
-        final String methodName = "get" + property.substring(0, 1).toUpperCase()
-                + property.substring(1);
+    public <S> Optional<Object> getProperty(final S object, final Class<? extends S> type, final String property) {
+        final String methodName = "get" + property.substring(0, 1).toUpperCase() + property.substring(1);
         try {
             final Method method = type.getMethod(methodName);
             // TODO: This is needed for AutoValues, should probably get return types not real types
@@ -77,8 +75,7 @@ public class EventPropertyManager {
 
             return Optional.ofNullable(result);
         } catch (ReflectiveOperationException ex) {
-            LOG.warn(USER_ERROR, "Unable to format event: could not retrieve property {}",
-                    ex.getMessage(), ex);
+            LOG.warn(USER_ERROR, "Unable to format event: could not retrieve property {}", property, ex);
         }
         return Optional.empty();
     }

--- a/src/main/java/com/dmdirc/ui/messages/Styliser.java
+++ b/src/main/java/com/dmdirc/ui/messages/Styliser.java
@@ -333,14 +333,17 @@ public class Styliser implements ConfigChangeListener, StyleApplier {
 
         // Nickname links
         if (string.charAt(0) == CODE_NICKNAME) {
+            int count = 1;
             if (state.isInLink) {
                 maker.endNicknameLink();
             } else {
-                maker.startNicknameLink(readUntilControl(string.substring(1)));
+                int next = string.indexOf(CODE_NICKNAME, 1);
+                maker.startNicknameLink(string.substring(1, next));
+                count += next;
             }
             state.isInLink = !state.isInLink;
 
-            return 1;
+            return count;
         }
 
         // Fixed pitch


### PR DESCRIPTION
If an object in a formatter tag ({{foo.bar.baz}}) is Displayable,
then we will modify the output based on its display properties.

Currently only supports user links and foreground colours.

This also changes the internal format of nickname links to be
`\u16<nick to link to>\u16<text to show>\u16`, allowing the
link and text to differ. This means if you formatted users
by showing their realname, you could still click them to
open a query.

Closes #424
Closes DMDirc/Plugins#507