### PR TITLE
Allow specifying a window for DisplayableEvents in format.yml (Issue #459)

### DIFF
--- a/api/src/main/java/com/dmdirc/events/DisplayLocation.java
+++ b/api/src/main/java/com/dmdirc/events/DisplayLocation.java
@@ -31,10 +31,10 @@ import java.util.function.BiPredicate;
  */
 public interface DisplayLocation {
     /** Event came from the same WindowModel. */
-    final DisplayLocation SOURCE = new DisplayLocationImpl((model, event) -> event.getSource().equals(model));
+    DisplayLocation SOURCE = new DisplayLocationImpl((model, event) -> event.getSource().equals(model));
 
     /** Event came from a WindowModel that shares the same connection. */
-    final DisplayLocation SAME_CONNECTION = new DisplayLocationImpl((model, event) -> event.getSource().getConnection().isPresent()
+    DisplayLocation SAME_CONNECTION = new DisplayLocationImpl((model, event) -> event.getSource().getConnection().isPresent()
             && model.getConnection().isPresent()
             && event.getSource().getConnection().get().equals(model.getConnection().get()));
     /**

--- a/api/src/main/java/com/dmdirc/events/DisplayLocation.java
+++ b/api/src/main/java/com/dmdirc/events/DisplayLocation.java
@@ -29,14 +29,15 @@ import java.util.function.BiPredicate;
 /**
  * Valid values for the DISPLAY_LOCATION property and how to test for them.
  */
+@FunctionalInterface
 public interface DisplayLocation {
     /** Event came from the same WindowModel. */
-    DisplayLocation SOURCE = new DisplayLocationImpl((model, event) -> event.getSource().equals(model));
+    DisplayLocation SOURCE = (model, event) -> event.getSource().equals(model);
 
     /** Event came from a WindowModel that shares the same connection. */
-    DisplayLocation SAME_CONNECTION = new DisplayLocationImpl((model, event) -> event.getSource().getConnection().isPresent()
+    DisplayLocation SAME_CONNECTION = (model, event) -> event.getSource().getConnection().isPresent()
             && model.getConnection().isPresent()
-            && event.getSource().getConnection().get().equals(model.getConnection().get()));
+            && event.getSource().getConnection().get().equals(model.getConnection().get());
     /**
      * Test to see if this location is valid.
      *
@@ -45,24 +46,4 @@ public interface DisplayLocation {
      * @return True if the event should be displayed here.
      */
     boolean shouldDisplay(final WindowModel model, final DisplayableEvent event);
-
-    final class DisplayLocationImpl implements DisplayLocation {
-        /**
-         * Function to test this DisplayLocation.
-         */
-        private BiPredicate<WindowModel, DisplayableEvent> locationTester;
-
-        /**
-         * Create a new DisplayLocation
-         *
-         * @param test Test function to run to see if this location is valid.
-         */
-        DisplayLocationImpl(final BiPredicate<WindowModel, DisplayableEvent> test) {
-            locationTester = test;
-        }
-
-        public boolean shouldDisplay(final WindowModel model, final DisplayableEvent event) {
-            return locationTester.test(model, event);
-        }
-    }
 };

--- a/api/src/main/java/com/dmdirc/events/DisplayLocation.java
+++ b/api/src/main/java/com/dmdirc/events/DisplayLocation.java
@@ -24,8 +24,6 @@ package com.dmdirc.events;
 
 import com.dmdirc.interfaces.WindowModel;
 
-import java.util.function.BiPredicate;
-
 /**
  * Valid values for the DISPLAY_LOCATION property and how to test for them.
  */

--- a/api/src/main/java/com/dmdirc/events/DisplayLocation.java
+++ b/api/src/main/java/com/dmdirc/events/DisplayLocation.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2006-2015 DMDirc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.dmdirc.events;
+
+import com.dmdirc.interfaces.WindowModel;
+
+/**
+ * Valid values for the DISPLAY_LOCATION property and how to test for them.
+ */
+public enum DisplayLocation {
+    /** Event came from the same WindowModel. */
+    SOURCE((model, event) -> event.getSource().equals(model)),
+
+    /** Event came from a WindowModel that shares the same connection. */
+    SAMECONNECTION((model, event) -> event.getSource().getConnection().isPresent()
+            && model.getConnection().isPresent()
+            && event.getSource().getConnection().get().equals(model.getConnection().get())),
+
+    /** Alias for SAMECONNECTION. */
+    SAMESERVER((model, event) -> SAMECONNECTION.shouldDisplay(model, event));
+
+    /** Function to test this DisplayLocation. */
+    private DisplayLocationTester locationTester;
+
+    /**
+     * Create a new DisplayLocation
+     *
+     * @param test Test function to run to see if this location is valid.
+     */
+    DisplayLocation(final DisplayLocationTester test) {
+        locationTester = test;
+    }
+
+    /**
+     * Test to see if this location is valid.
+     *
+     * @param model WindowModel we are wanting to display the event in.
+     * @param event Event we are wanting to display.
+     * @return True if the event should be displayed here.
+     */
+    public boolean shouldDisplay(final WindowModel model, final DisplayableEvent event) {
+        return locationTester.test(model, event);
+    }
+
+    interface DisplayLocationTester {
+        public boolean test(final WindowModel model, final DisplayableEvent event);
+    }
+};

--- a/api/src/main/java/com/dmdirc/events/DisplayLocation.java
+++ b/api/src/main/java/com/dmdirc/events/DisplayLocation.java
@@ -63,6 +63,6 @@ public enum DisplayLocation {
     }
 
     interface DisplayLocationTester {
-        public boolean test(final WindowModel model, final DisplayableEvent event);
+        boolean test(final WindowModel model, final DisplayableEvent event);
     }
 };

--- a/api/src/main/java/com/dmdirc/events/DisplayProperty.java
+++ b/api/src/main/java/com/dmdirc/events/DisplayProperty.java
@@ -39,6 +39,8 @@ public interface DisplayProperty<T> {
     DisplayProperty<Boolean> DO_NOT_DISPLAY = new DisplayPropertyImpl<>();
     /** Whether to suppress timestamps for the event. */
     DisplayProperty<Boolean> NO_TIMESTAMPS = new DisplayPropertyImpl<>();
+    /** Where the event should be displayed. */
+    DisplayProperty<DisplayLocation> DISPLAY_LOCATION = new DisplayPropertyImpl<>();
     /** A user that the displayable is linked to. */
     DisplayProperty<User> LINK_USER = new DisplayPropertyImpl<>();
 

--- a/src/main/java/com/dmdirc/plugins/PluginEventFormatManager.java
+++ b/src/main/java/com/dmdirc/plugins/PluginEventFormatManager.java
@@ -21,11 +21,8 @@ import com.dmdirc.config.GlobalConfig;
 import com.dmdirc.events.PluginLoadedEvent;
 import com.dmdirc.events.PluginUnloadedEvent;
 import com.dmdirc.events.eventbus.EventBus;
+import com.dmdirc.ui.messages.*;
 import com.dmdirc.util.system.SystemLifecycleComponent;
-import com.dmdirc.ui.messages.ColourManager;
-import com.dmdirc.ui.messages.EventFormatProvider;
-import com.dmdirc.ui.messages.MultiEventFormatProvider;
-import com.dmdirc.ui.messages.YamlEventFormatProvider;
 import net.engio.mbassy.listener.Handler;
 
 import javax.inject.Inject;
@@ -48,15 +45,18 @@ public class PluginEventFormatManager implements SystemLifecycleComponent {
     private final MultiEventFormatProvider multiEventFormatProvider;
     private final Map<PluginInfo, EventFormatProvider> providers = new HashMap<>();
     private final ColourManager colourManager;
+    private final DisplayLocationManager displayLocationManager;
 
     @Inject
     public PluginEventFormatManager(
             final EventBus eventbus,
             final MultiEventFormatProvider multiEventFormatProvider,
-            @GlobalConfig final ColourManager colourManager) {
+            @GlobalConfig final ColourManager colourManager,
+            final DisplayLocationManager displayLocationManager) {
         this.eventbus = eventbus;
         this.multiEventFormatProvider = multiEventFormatProvider;
         this.colourManager = colourManager;
+        this.displayLocationManager = displayLocationManager;
     }
 
     @Override
@@ -74,7 +74,7 @@ public class PluginEventFormatManager implements SystemLifecycleComponent {
         final Path path = event.getPlugin().getPath("/META-INF/format.yml");
         if (Files.exists(path)) {
             final YamlEventFormatProvider provider =
-                    new YamlEventFormatProvider(path, colourManager);
+                    new YamlEventFormatProvider(path, colourManager, displayLocationManager);
             provider.load();
             providers.put(event.getPlugin(), provider);
             multiEventFormatProvider.addProvider(provider);

--- a/src/main/java/com/dmdirc/plugins/PluginEventFormatManager.java
+++ b/src/main/java/com/dmdirc/plugins/PluginEventFormatManager.java
@@ -25,6 +25,7 @@ import com.dmdirc.ui.messages.ColourManager;
 import com.dmdirc.ui.messages.EventFormatProvider;
 import com.dmdirc.ui.messages.MultiEventFormatProvider;
 import com.dmdirc.ui.messages.YamlEventFormatProvider;
+import com.dmdirc.ui.messages.DisplayLocationManager;
 import com.dmdirc.util.system.SystemLifecycleComponent;
 import net.engio.mbassy.listener.Handler;
 

--- a/src/main/java/com/dmdirc/plugins/PluginEventFormatManager.java
+++ b/src/main/java/com/dmdirc/plugins/PluginEventFormatManager.java
@@ -21,7 +21,10 @@ import com.dmdirc.config.GlobalConfig;
 import com.dmdirc.events.PluginLoadedEvent;
 import com.dmdirc.events.PluginUnloadedEvent;
 import com.dmdirc.events.eventbus.EventBus;
-import com.dmdirc.ui.messages.*;
+import com.dmdirc.ui.messages.ColourManager;
+import com.dmdirc.ui.messages.EventFormatProvider;
+import com.dmdirc.ui.messages.MultiEventFormatProvider;
+import com.dmdirc.ui.messages.YamlEventFormatProvider;
 import com.dmdirc.util.system.SystemLifecycleComponent;
 import net.engio.mbassy.listener.Handler;
 

--- a/src/main/java/com/dmdirc/ui/messages/BackBufferImpl.java
+++ b/src/main/java/com/dmdirc/ui/messages/BackBufferImpl.java
@@ -19,7 +19,6 @@ package com.dmdirc.ui.messages;
 
 import com.dmdirc.events.DisplayLocation;
 import com.dmdirc.events.DisplayProperty;
-import com.dmdirc.events.DisplayPropertyMap;
 import com.dmdirc.events.DisplayableEvent;
 import com.dmdirc.events.eventbus.EventBus;
 import com.dmdirc.interfaces.WindowModel;

--- a/src/main/java/com/dmdirc/ui/messages/BackBufferImpl.java
+++ b/src/main/java/com/dmdirc/ui/messages/BackBufferImpl.java
@@ -19,6 +19,7 @@ package com.dmdirc.ui.messages;
 
 import com.dmdirc.events.DisplayLocation;
 import com.dmdirc.events.DisplayProperty;
+import com.dmdirc.events.DisplayPropertyMap;
 import com.dmdirc.events.DisplayableEvent;
 import com.dmdirc.events.eventbus.EventBus;
 import com.dmdirc.interfaces.WindowModel;
@@ -86,8 +87,10 @@ public class BackBufferImpl implements BackBuffer {
      * @return True if the event should be displayed, false otherwise.
      */
     private boolean shouldDisplay(final DisplayableEvent event) {
-        return formatter.getFormatDisplayableProperties(event).get(DisplayProperty.DISPLAY_LOCATION)
-                    .orElse(DisplayLocation.SOURCE).shouldDisplay(owner, event)
+        return (formatter.getEventFormatProvider().getFormat(event.getClass()).isPresent() ?
+                formatter.getEventFormatProvider().getFormat(event.getClass()).get().getDisplayProperties()
+                    .get(DisplayProperty.DISPLAY_LOCATION).orElse(DisplayLocation.SOURCE).shouldDisplay(owner, event)
+                        : DisplayLocation.SOURCE.shouldDisplay(owner, event))
                 && !event.hasDisplayProperty(DisplayProperty.DO_NOT_DISPLAY);
     }
 

--- a/src/main/java/com/dmdirc/ui/messages/BackBufferImpl.java
+++ b/src/main/java/com/dmdirc/ui/messages/BackBufferImpl.java
@@ -17,7 +17,9 @@
 
 package com.dmdirc.ui.messages;
 
+import com.dmdirc.events.DisplayLocation;
 import com.dmdirc.events.DisplayProperty;
+import com.dmdirc.events.DisplayPropertyMap;
 import com.dmdirc.events.DisplayableEvent;
 import com.dmdirc.events.eventbus.EventBus;
 import com.dmdirc.interfaces.WindowModel;
@@ -85,7 +87,8 @@ public class BackBufferImpl implements BackBuffer {
      * @return True if the event should be displayed, false otherwise.
      */
     private boolean shouldDisplay(final DisplayableEvent event) {
-        return event.getSource().equals(owner)
+        return formatter.getFormatDisplayableProperties(event).get(DisplayProperty.DISPLAY_LOCATION)
+                    .orElse(DisplayLocation.SOURCE).shouldDisplay(owner, event)
                 && !event.hasDisplayProperty(DisplayProperty.DO_NOT_DISPLAY);
     }
 

--- a/src/main/java/com/dmdirc/ui/messages/DisplayLocationManager.java
+++ b/src/main/java/com/dmdirc/ui/messages/DisplayLocationManager.java
@@ -28,7 +28,7 @@ import java.util.Set;
 
 @Singleton
 public class DisplayLocationManager {
-    public Map<String, DisplayLocation> displayLocations = new HashMap<>();
+    private final Map<String, DisplayLocation> displayLocations = new HashMap<>();
 
     @Inject
     DisplayLocationManager() {

--- a/src/main/java/com/dmdirc/ui/messages/DisplayLocationManager.java
+++ b/src/main/java/com/dmdirc/ui/messages/DisplayLocationManager.java
@@ -17,39 +17,36 @@
 
 package com.dmdirc.ui.messages;
 
-import com.dmdirc.commandline.CommandLineOptionsModule.Directory;
-import com.dmdirc.config.GlobalConfig;
-import dagger.Module;
-import dagger.Provides;
+import com.dmdirc.events.DisplayLocation;
 
+import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
-import static com.dmdirc.commandline.CommandLineOptionsModule.DirectoryType.BASE;
+@Singleton
+public class DisplayLocationManager {
+    public Map<String, DisplayLocation> displayLocations = new HashMap<>();
 
-/**
- * Dagger module for message related objects.
- */
-@SuppressWarnings("TypeMayBeWeakened")
-@Module(library = true, complete = false)
-public class UiMessagesModule {
-
-    @Provides
-    @Singleton
-    public MultiEventFormatProvider getTemplateProvider(
-            @Directory(BASE) final Path directory,
-            @GlobalConfig final ColourManager colourManager,
-            final DisplayLocationManager displayLocationManager) {
-        final YamlEventFormatProvider yamlProvider =
-                new YamlEventFormatProvider(directory.resolve("format.yml"), colourManager, displayLocationManager);
-        yamlProvider.load();
-        return new MultiEventFormatProvider(yamlProvider);
+    @Inject
+    DisplayLocationManager() {
+        // Add Defaults
+        addDisplayLocation("source", DisplayLocation.SOURCE);
+        addDisplayLocation("sameconnection", DisplayLocation.SAME_CONNECTION);
+        addDisplayLocation("sameserver", DisplayLocation.SAME_CONNECTION);
     }
 
-    @Provides
-    @Singleton
-    public EventFormatProvider getTemplateProvider(final MultiEventFormatProvider provider) {
-        return provider;
+    public void addDisplayLocation(final String name, final DisplayLocation displayLocation) {
+        displayLocations.put(name.toLowerCase().replaceAll("[^a-z]", ""), displayLocation);
     }
 
+    public Optional<DisplayLocation> getDisplayLocation(final String name) {
+        return Optional.ofNullable(displayLocations.get(name.toLowerCase().replaceAll("[^a-z]", "")));
+    }
+
+    public Set<String> getDisplayLocations() {
+        return displayLocations.keySet();
+    }
 }

--- a/src/main/java/com/dmdirc/ui/messages/EventFormatter.java
+++ b/src/main/java/com/dmdirc/ui/messages/EventFormatter.java
@@ -155,15 +155,7 @@ public class EventFormatter {
         return res.toString();
     }
 
-    /**
-     * Get the displayable properties map for this event according to the formatter.
-     *
-     * @param event Event to get properties for.
-     * @return DisplayPropertyMap from formatter.
-     */
-    public DisplayPropertyMap getFormatDisplayableProperties(final DisplayableEvent event) {
-        return formatProvider.getFormat(event.getClass()).isPresent()
-                ? formatProvider.getFormat(event.getClass()).get().getDisplayProperties()
-                : event.getDisplayProperties();
+    public EventFormatProvider getEventFormatProvider() {
+        return formatProvider;
     }
 }

--- a/src/main/java/com/dmdirc/ui/messages/EventFormatter.java
+++ b/src/main/java/com/dmdirc/ui/messages/EventFormatter.java
@@ -155,4 +155,15 @@ public class EventFormatter {
         return res.toString();
     }
 
+    /**
+     * Get the displayable properties map for this event according to the formatter.
+     *
+     * @param event Event to get properties for.
+     * @return DisplayPropertyMap from formatter.
+     */
+    public DisplayPropertyMap getFormatDisplayableProperties(final DisplayableEvent event) {
+        return formatProvider.getFormat(event.getClass()).isPresent()
+                ? formatProvider.getFormat(event.getClass()).get().getDisplayProperties()
+                : event.getDisplayProperties();
+    }
 }

--- a/src/main/java/com/dmdirc/ui/messages/YamlEventFormatProvider.java
+++ b/src/main/java/com/dmdirc/ui/messages/YamlEventFormatProvider.java
@@ -131,7 +131,7 @@ public class YamlEventFormatProvider implements EventFormatProvider {
             } catch (final IllegalArgumentException iae) {
                 LOG.info(USER_ERROR, "Invalid displaywindow specified for: {}.\nValid values are: {}",
                         info.get("displaywindow").toString(),
-                        Arrays.toString(displayLocationManager.getDisplayLocations().toArray()));
+                        displayLocationManager.getDisplayLocations().toString());
             }
         }
         return map;

--- a/src/main/java/com/dmdirc/ui/messages/YamlEventFormatProvider.java
+++ b/src/main/java/com/dmdirc/ui/messages/YamlEventFormatProvider.java
@@ -54,11 +54,14 @@ public class YamlEventFormatProvider implements EventFormatProvider {
 
     private final Path path;
     private final ColourManager colourManager;
+    private final DisplayLocationManager displayLocationManager;
     private final Map<String, EventFormat> formats = new HashMap<>();
 
-    public YamlEventFormatProvider(final Path path, final ColourManager colourManager) {
+    public YamlEventFormatProvider(final Path path, final ColourManager colourManager,
+                                   final DisplayLocationManager displayLocationManager) {
         this.path = path;
         this.colourManager = colourManager;
+        this.displayLocationManager = displayLocationManager;
     }
 
     public void load() {
@@ -124,11 +127,12 @@ public class YamlEventFormatProvider implements EventFormatProvider {
         }
         if (info.containsKey("displaywindow")) {
             try {
-                map.put(DisplayProperty.DISPLAY_LOCATION,
-                        DisplayLocation.valueOf(info.get("displaywindow").toString().toUpperCase()));
+                map.put(DisplayProperty.DISPLAY_LOCATION, displayLocationManager.getDisplayLocation(
+                        info.get("displaywindow").toString()).orElseThrow(() -> new IllegalArgumentException()));
             } catch (final IllegalArgumentException iae) {
                 LOG.info(USER_ERROR, "Invalid displaywindow specified for: {}.\nValid values are: {}",
-                        info.get("displaywindow").toString(), Arrays.toString(DisplayLocation.values()));
+                        info.get("displaywindow").toString(),
+                        Arrays.toString(displayLocationManager.getDisplayLocations().toArray()));
             }
         }
         return map;

--- a/src/main/java/com/dmdirc/ui/messages/YamlEventFormatProvider.java
+++ b/src/main/java/com/dmdirc/ui/messages/YamlEventFormatProvider.java
@@ -17,6 +17,7 @@
 
 package com.dmdirc.ui.messages;
 
+import com.dmdirc.events.DisplayLocation;
 import com.dmdirc.events.DisplayProperty;
 import com.dmdirc.events.DisplayPropertyMap;
 import com.dmdirc.events.DisplayableEvent;
@@ -27,6 +28,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -119,6 +121,15 @@ public class YamlEventFormatProvider implements EventFormatProvider {
         if (info.containsKey("timestamp")) {
             map.put(DisplayProperty.NO_TIMESTAMPS,
                     !info.get("timestamp").toString().toLowerCase().matches("y|yes|true|1|on"));
+        }
+        if (info.containsKey("displaywindow")) {
+            try {
+                map.put(DisplayProperty.DISPLAY_LOCATION,
+                        DisplayLocation.valueOf(info.get("displaywindow").toString().toUpperCase()));
+            } catch (final IllegalArgumentException iae) {
+                LOG.info(USER_ERROR, "Invalid displaywindow specified for: {}.\nValid values are: {}",
+                        info.get("displaywindow").toString(), Arrays.toString(DisplayLocation.values()));
+            }
         }
         return map;
     }

--- a/src/main/java/com/dmdirc/ui/messages/YamlEventFormatProvider.java
+++ b/src/main/java/com/dmdirc/ui/messages/YamlEventFormatProvider.java
@@ -27,7 +27,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;

--- a/src/main/java/com/dmdirc/ui/messages/YamlEventFormatProvider.java
+++ b/src/main/java/com/dmdirc/ui/messages/YamlEventFormatProvider.java
@@ -17,7 +17,6 @@
 
 package com.dmdirc.ui.messages;
 
-import com.dmdirc.events.DisplayLocation;
 import com.dmdirc.events.DisplayProperty;
 import com.dmdirc.events.DisplayPropertyMap;
 import com.dmdirc.events.DisplayableEvent;


### PR DESCRIPTION
I'm sure this will be changed/redone, but this is at least a start by allowing
certain events to go to all windows (eg ServerNotices)

Ideally it would be possible for some events to only be displayed in the window
that generated them (eg if I do /notice foo bar the ">-{{target}}-> {{message}}"
message only appears in the window I ran the command in, not either just the
server window or all the windows, but this would need changes to a bunch of
events to make them include a source window.