### PR TITLE
Apply display properties to a value before running functions on it.

### DIFF
--- a/src/main/java/com/dmdirc/ui/messages/EventFormatter.java
+++ b/src/main/java/com/dmdirc/ui/messages/EventFormatter.java
@@ -129,12 +129,12 @@ public class EventFormatter {
             }
         }
 
-        String value = target.toString();
+        String value = applyDisplayProperties(displayProperties, target.toString());
         for (int i = 1; i < functionParts.length; i++) {
             value = propertyManager.applyFunction(value, functionParts[i]);
         }
 
-        return applyDisplayProperties(displayProperties, value);
+        return value;
     }
 
     // TODO: It should be possible for plugins etc to add new ways of applying properties.


### PR DESCRIPTION
This allows "unstyled" to actually work.

Closes #755