### PR TITLE
Publish channel events using publish() not publishAsync() to ensure correct ordering.

### DIFF
--- a/src/main/java/com/dmdirc/ChannelEventHandler.java
+++ b/src/main/java/com/dmdirc/ChannelEventHandler.java
@@ -176,7 +176,7 @@ public class ChannelEventHandler extends EventHandler {
             return;
         }
 
-        eventBus.publish(new ChannelJoinEvent(
+        eventBus.publishAsync(new ChannelJoinEvent(
                 event.getDate(), owner,
                 groupChatUserManager.getUserFromClient(event.getClient(), owner)));
         owner.addClient(groupChatUserManager.getUserFromClient(event.getClient(), owner));


### PR DESCRIPTION
Issue DMDirc/DMDirc#791