### PR TITLE
Fix handling of special chars in passwords when using /newserver.

### DIFF
--- a/src/main/java/com/dmdirc/util/URIParser.java
+++ b/src/main/java/com/dmdirc/util/URIParser.java
@@ -90,7 +90,8 @@ public class URIParser {
             // User info may contain special characters. When we pass individual parts to
             // the URI constructor below, it encodes any characters not allowed in the user
             // info. To avoid doubly-encoding them we need to decode here...
-            userInfo = URLDecoder.decode(authorityMatcher.group("auth"), "UTF-8");
+            String auth = authorityMatcher.group("auth");
+            userInfo = auth == null ? null : URLDecoder.decode(auth, "UTF-8");
         } catch (UnsupportedEncodingException ex) {
             throw new InvalidURIException("Unable to create user info", ex);
         }

--- a/src/main/java/com/dmdirc/util/URIParser.java
+++ b/src/main/java/com/dmdirc/util/URIParser.java
@@ -17,8 +17,10 @@
 
 package com.dmdirc.util;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLDecoder;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -83,7 +85,16 @@ public class URIParser {
         if (!authorityMatcher.matches()) {
             throw new InvalidURIException("Invalid address specified");
         }
-        userInfo = authorityMatcher.group("auth");
+
+        try {
+            // User info may contain special characters. When we pass individual parts to
+            // the URI constructor below, it encodes any characters not allowed in the user
+            // info. To avoid doubly-encoding them we need to decode here...
+            userInfo = URLDecoder.decode(authorityMatcher.group("auth"), "UTF-8");
+        } catch (UnsupportedEncodingException ex) {
+            throw new InvalidURIException("Unable to create user info", ex);
+        }
+
         host = authorityMatcher.group("host");
         if (authorityMatcher.group("secure") != null && scheme.charAt(scheme.length() - 1) != 's') {
             scheme += "s";

--- a/src/test/java/com/dmdirc/util/URIParserURIParameterizedTest.java
+++ b/src/test/java/com/dmdirc/util/URIParserURIParameterizedTest.java
@@ -55,7 +55,9 @@ public class URIParserURIParameterizedTest {
             {"irc://irc.test.com:+6667", "ircs://irc.test.com:6667"},
             {"ircs://irc.test.com:+6667", "ircs://irc.test.com:6667"},
             {"ircs://irc.test.com:+6667", "ircs://irc.test.com:6667"},
-            {"ircs://username@irc.test.com:+6667", "ircs://username@irc.test.com:6667"},});
+            {"ircs://username@irc.test.com:+6667", "ircs://username@irc.test.com:6667"},
+            {"ircs://username:password%2Fnetwork@irc.test.com:+6667", "ircs://username:password%2Fnetwork@irc.test.com:6667"},
+        });
     }
 
 }


### PR DESCRIPTION
Because of the weird string->URI parts->URI conversion we do,
we have to manually decode special entities when converting
them into URI parts. (Otherwise the URI constructor encodes
them a second time)